### PR TITLE
fix: FallbackAdapter list_market_quotes/get_quotes 返回 [] 而非 None

### DIFF
--- a/src/mommy_chaogu/market_data/fallback_adapter.py
+++ b/src/mommy_chaogu/market_data/fallback_adapter.py
@@ -118,10 +118,12 @@ class FallbackAdapter:
         return self._try_call("get_quote", code)
 
     def get_quotes(self, codes: list[str]):
-        return self._try_call("get_quotes", codes)
+        result = self._try_call("get_quotes", codes)
+        return result if result is not None else []
 
     def list_market_quotes(self):
-        return self._try_call("list_market_quotes")
+        result = self._try_call("list_market_quotes")
+        return result if result is not None else []
 
     def get_order_book(self, code: str):
         return self._try_call("get_order_book", code)

--- a/src/mommy_chaogu/monitor/poller.py
+++ b/src/mommy_chaogu/monitor/poller.py
@@ -135,7 +135,7 @@ class Monitor:
 
         # 2. 拉全市场快照（稳定接口）
         try:
-            all_quotes = self.adapter.list_market_quotes()
+            all_quotes = self.adapter.list_market_quotes() or []
         except Exception as e:
             _log.error("list_market_quotes failed: %s", e)
             all_quotes = []

--- a/tests/test_market_data/test_fallback_adapter.py
+++ b/tests/test_market_data/test_fallback_adapter.py
@@ -1,0 +1,126 @@
+"""FallbackAdapter 单测。
+
+重点覆盖 issue #3：
+- list_market_quotes() / get_quotes() 全部 adapter 失败时返回 [] 而非 None
+- Monitor.snapshot_now() 不再因 None 崩溃
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from mommy_chaogu.market_data.fallback_adapter import FallbackAdapter
+
+# ---------- helpers ----------
+
+
+@dataclass
+class _MockAdapter:
+    """极简 mock adapter，只实现 _try_call 走的几个方法。"""
+
+    name: str
+    # 每个方法的返回值；SENTINEL 表示该方法不存在
+    list_market_quotes_ret: Any = "SENTINEL"
+    get_quotes_ret: Any = "SENTINEL"
+    get_quote_ret: Any = "SENTINEL"
+    # 控制是否抛异常
+    raise_on: set[str] = field(default_factory=set)
+
+    def list_market_quotes(self):
+        if "list_market_quotes" in self.raise_on:
+            raise RuntimeError(f"{self.name}: boom")
+        return self.list_market_quotes_ret if self.list_market_quotes_ret != "SENTINEL" else None
+
+    def get_quotes(self, codes: list[str]):
+        if "get_quotes" in self.raise_on:
+            raise RuntimeError(f"{self.name}: boom")
+        return self.get_quotes_ret if self.get_quotes_ret != "SENTINEL" else None
+
+    def get_quote(self, code: str):
+        if "get_quote" in self.raise_on:
+            raise RuntimeError(f"{self.name}: boom")
+        return self.get_quote_ret if self.get_quote_ret != "SENTINEL" else None
+
+
+# ---------- list_market_quotes ----------
+
+
+class TestListMarketQuotes:
+    def test_primary_success(self):
+        primary = _MockAdapter("primary", list_market_quotes_ret=["q1", "q2"])
+        fb = FallbackAdapter([primary, _MockAdapter("backup")])
+        assert fb.list_market_quotes() == ["q1", "q2"]
+
+    def test_fallback_when_primary_returns_empty(self):
+        """主源返回 [] → 视为失败 → 走 fallback。"""
+        primary = _MockAdapter("primary", list_market_quotes_ret=[])
+        backup = _MockAdapter("backup", list_market_quotes_ret=["q1"])
+        fb = FallbackAdapter([primary, backup])
+        assert fb.list_market_quotes() == ["q1"]
+
+    def test_all_fail_returns_empty_list_not_none(self):
+        """issue #3 核心：全部失败时返回 [] 而非 None。"""
+        primary = _MockAdapter("primary", list_market_quotes_ret=None)
+        backup = _MockAdapter("backup", list_market_quotes_ret=None)
+        fb = FallbackAdapter([primary, backup])
+        result = fb.list_market_quotes()
+        assert result is not None
+        assert result == []
+
+    def test_all_raise_returns_empty_list_not_none(self):
+        """全部抛异常也返回 []。"""
+        primary = _MockAdapter("primary", raise_on={"list_market_quotes"})
+        backup = _MockAdapter("backup", raise_on={"list_market_quotes"})
+        fb = FallbackAdapter([primary, backup])
+        result = fb.list_market_quotes()
+        assert result is not None
+        assert result == []
+
+    def test_stats_all_fail_counter(self):
+        primary = _MockAdapter("primary", list_market_quotes_ret=None)
+        fb = FallbackAdapter([primary])
+        fb.list_market_quotes()
+        assert fb.stats()["__total__"]["all_fail"] == 1
+
+
+# ---------- get_quotes ----------
+
+
+class TestGetQuotes:
+    def test_primary_success(self):
+        primary = _MockAdapter("primary", get_quotes_ret=["q1"])
+        fb = FallbackAdapter([primary])
+        assert fb.get_quotes(["600519"]) == ["q1"]
+
+    def test_all_fail_returns_empty_list_not_none(self):
+        """issue #3：get_quotes 同理。"""
+        primary = _MockAdapter("primary", get_quotes_ret=None)
+        backup = _MockAdapter("backup", get_quotes_ret=None)
+        fb = FallbackAdapter([primary, backup])
+        result = fb.get_quotes(["600519"])
+        assert result is not None
+        assert result == []
+
+    def test_all_raise_returns_empty_list_not_none(self):
+        primary = _MockAdapter("primary", raise_on={"get_quotes"})
+        fb = FallbackAdapter([primary])
+        result = fb.get_quotes(["600519"])
+        assert result is not None
+        assert result == []
+
+
+# ---------- get_quote (单股，已有 None 处理，回归保护) ----------
+
+
+class TestGetQuote:
+    def test_all_fail_returns_none(self):
+        """单股接口全部失败时仍返回 None（这是预期的——调用方已处理）。"""
+        primary = _MockAdapter("primary", get_quote_ret=None)
+        fb = FallbackAdapter([primary])
+        assert fb.get_quote("600519") is None
+
+    def test_primary_success(self):
+        primary = _MockAdapter("primary", get_quote_ret="q1")
+        fb = FallbackAdapter([primary])
+        assert fb.get_quote("600519") == "q1"


### PR DESCRIPTION
## 修复内容

Closes #3

### 根因
`FallbackAdapter._try_call()` 在所有 adapter 都失败时返回 `None`，但 `list_market_quotes()` 和 `get_quotes()` 的类型签名是 `list[Quote]`。下游 `Monitor.snapshot_now()` 直接 `for q in all_quotes` → `TypeError: 'NoneType' object is not iterable`。

### 改动

**方案 A（源头修复）** — `fallback_adapter.py`：
- `list_market_quotes()`：全 fail 时返回 `[]` 而非 `None`
- `get_quotes()`：同理

**方案 B（调用方防御）** — `poller.py`：
- `snapshot_now()` 加 `or []` 双保险

**测试** — 新增 `tests/test_market_data/test_fallback_adapter.py`（8 个 case）：
- primary success / fallback when primary empty
- all-fail returns `[]` not `None`（issue #3 核心）
- all-raise returns `[]` not `None`
- stats all_fail counter

### 质量门
- ✅ ruff: All checks passed
- ✅ mypy --strict: 0 issues
- ✅ pytest: 302 passed (0 failed)
