### PR TITLE
fix(agent): 工具异常回传 LLM + LLM 调用指数退避重试

### DIFF
--- a/src/mommy_chaogu/agent/service.py
+++ b/src/mommy_chaogu/agent/service.py
@@ -8,6 +8,10 @@
       ├─ 是 → 执行每个 tool_call → 结果回传 → 再给 LLM
       └─ 否 → 返回最终文本
 循环最多 max_tool_calls 次
+
+容错：
+- 工具执行抛异常时不中断对话，错误以 {"error": ...} 形式回传给 LLM 自行恢复
+- LLM 调用的瞬时错误（连接 / 限流 / 5xx）按指数退避重试，最多 max_retries 次
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ import contextlib
 import json
 import logging
 import os
+import random
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -107,6 +112,8 @@ class AgentService:
         provider: str | None = None,
         api_key: str | None = None,
         max_tool_calls: int = 10,
+        max_retries: int = 3,
+        retry_base_delay: float = 1.0,
         episodic: Any | None = None,
         tracker: Any | None = None,
         semantic: Any | None = None,
@@ -115,6 +122,8 @@ class AgentService:
     ) -> None:
         self._tools = ToolRegistry(ctx)
         self._max_tool_calls = max_tool_calls
+        self._max_retries = max_retries
+        self._retry_base_delay = retry_base_delay
         self._ctx = ctx
 
         # 解析 provider 配置
@@ -232,6 +241,39 @@ class AgentService:
         """直接传入完整 messages 列表（灵活但需自己构造格式）。"""
         return self._run_loop(messages, on_tool_call=on_tool_call, on_tool_result=on_tool_result)
 
+    def _create_with_retry(self, messages: list[dict[str, Any]]) -> Any:
+        """调用 LLM，对瞬时错误（连接 / 限流 / 5xx）按指数退避重试。
+
+        重试 max_retries 次后仍失败则抛出最后一次异常（上游 CLI / TUI / Web
+        均有 try/except 兜底展示）。认证、参数等非瞬时错误不重试，直接抛出。
+        """
+        from openai import APIConnectionError, InternalServerError, RateLimitError
+
+        retryable = (APIConnectionError, RateLimitError, InternalServerError)
+
+        for attempt in range(self._max_retries + 1):
+            try:
+                return self._client.chat.completions.create(
+                    model=self._model,
+                    messages=messages,
+                    tools=self._tools.definitions(),
+                    **self._completion_options,
+                )
+            except retryable as exc:
+                if attempt >= self._max_retries:
+                    _log.error("LLM 调用重试 %d 次后仍失败: %s", self._max_retries, exc)
+                    raise
+                delay = self._retry_base_delay * (2**attempt) + random.uniform(0, 0.5)
+                _log.warning(
+                    "LLM 调用失败（第 %d/%d 次）: %s — %.1fs 后重试",
+                    attempt + 1,
+                    self._max_retries + 1,
+                    exc,
+                    delay,
+                )
+                time.sleep(delay)
+        raise AssertionError("unreachable")  # pragma: no cover
+
     def _run_loop(
         self,
         messages: list[dict[str, Any]],
@@ -250,12 +292,7 @@ class AgentService:
         while rounds < self._max_tool_calls:
             rounds += 1
 
-            response = self._client.chat.completions.create(
-                model=self._model,
-                messages=messages,
-                tools=self._tools.definitions(),
-                **self._completion_options,
-            )
+            response = self._create_with_retry(messages)
 
             msg = response.choices[0].message
 
@@ -287,11 +324,23 @@ class AgentService:
                 try:
                     result = self._tools.call(fn_name, fn_args)
                 except Exception as exc:
+                    # 工具异常不中断整轮对话：把错误作为 tool 结果回传，
+                    # 让 LLM 决定换工具重试，或在回答中向用户说明。
+                    elapsed_ms = int((time.monotonic() - started) * 1000)
+                    _log.warning("工具 %s 抛异常，错误将回传给 LLM: %s", fn_name, exc)
+                    result = json.dumps({"error": f"工具执行异常: {exc}"}, ensure_ascii=False)
                     if on_tool_result is not None:
-                        elapsed_ms = int((time.monotonic() - started) * 1000)
                         with contextlib.suppress(Exception):
                             on_tool_result(fn_name, False, elapsed_ms, str(exc))
-                    raise
+                    all_tool_calls.append(ToolCallRecord(fn_name, fn_args, result))
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": result,
+                        }
+                    )
+                    continue
                 if on_tool_result is not None:
                     elapsed_ms = int((time.monotonic() - started) * 1000)
                     with contextlib.suppress(Exception):

--- a/tests/test_agent/test_service_resilience.py
+++ b/tests/test_agent/test_service_resilience.py
@@ -1,0 +1,189 @@
+"""AgentService 容错回归测试：工具异常恢复 + LLM 瞬时错误重试。"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from openai import APIConnectionError, BadRequestError, RateLimitError
+
+from mommy_chaogu.agent.service import AgentService
+from mommy_chaogu.agent.tools import ToolContext
+
+
+@pytest.fixture
+def mock_ctx() -> ToolContext:
+    """minimal ToolContext with mock adapter."""
+    adp = MagicMock()
+    adp.get_quote.return_value = None
+    return ToolContext(adapter=adp)
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("POST", "https://api.deepseek.com/chat/completions")
+
+
+def _rate_limit_err() -> RateLimitError:
+    resp = httpx.Response(429, request=_request())
+    return RateLimitError("rate limited", response=resp, body=None)
+
+
+def _conn_err() -> APIConnectionError:
+    return APIConnectionError(message="connection reset", request=_request())
+
+
+def _text_response(text: str) -> MagicMock:
+    msg = MagicMock()
+    msg.tool_calls = None
+    msg.content = text
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message = msg
+    return resp
+
+
+def _tool_call_response(name: str = "get_quote", args: str = '{"code": "600519"}') -> MagicMock:
+    msg = MagicMock()
+    msg.tool_calls = [MagicMock()]
+    msg.tool_calls[0].id = "tc_1"
+    msg.tool_calls[0].function.name = name
+    msg.tool_calls[0].function.arguments = args
+    msg.model_dump.return_value = {"role": "assistant", "content": None}
+    msg.content = None
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message = msg
+    return resp
+
+
+def _make_broken_tools(svc: AgentService, exc: Exception) -> None:
+    """把 svc 的工具注册表换成一个 call 必抛异常的 mock。"""
+    broken = MagicMock()
+    broken.definitions.return_value = []
+    broken.call.side_effect = exc
+    svc._tools = broken
+
+
+class TestToolErrorRecovery:
+    """工具执行抛异常时不应中断整轮对话，错误应回传给 LLM。"""
+
+    @patch("openai.OpenAI")
+    def test_tool_exception_does_not_kill_turn(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """工具炸了，LLM 看到错误后仍给出降级回答，整轮不抛异常。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _tool_call_response(),
+            _text_response("行情接口暂时不可用，请稍后再试。"),
+        ]
+        _make_broken_tools(svc, RuntimeError("东财接口超时"))
+
+        resp = svc.chat("茅台多少钱")
+
+        assert "暂时不可用" in resp.text
+        assert resp.rounds == 2
+        assert len(resp.tool_calls) == 1
+        assert resp.tool_calls[0].name == "get_quote"
+        assert "工具执行异常" in resp.tool_calls[0].result
+
+    @patch("openai.OpenAI")
+    def test_tool_error_fed_back_as_tool_message(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """工具异常以 {"error": ...} JSON 形式作为 tool 消息回传给 LLM。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _tool_call_response(),
+            _text_response("抱歉，查询失败"),
+        ]
+        _make_broken_tools(svc, RuntimeError("东财接口超时"))
+
+        svc.chat("茅台多少钱")
+
+        create_mock = svc._client.chat.completions.create
+        second_call_messages: list[dict[str, Any]] = create_mock.call_args_list[1].kwargs[
+            "messages"
+        ]
+        tool_msgs = [m for m in second_call_messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        payload = json.loads(tool_msgs[0]["content"])
+        assert "东财接口超时" in payload["error"]
+
+    @patch("openai.OpenAI")
+    def test_tool_error_invokes_on_tool_result_with_failure(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """TUI 的 on_tool_result 回调收到 ok=False，用于渲染工具失败状态。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _tool_call_response(),
+            _text_response("降级回答"),
+        ]
+        _make_broken_tools(svc, RuntimeError("东财接口超时"))
+
+        events: list[tuple[str, bool, int, str]] = []
+        svc.chat(
+            "茅台多少钱",
+            on_tool_result=lambda name, ok, ms, res: events.append((name, ok, ms, res)),
+        )
+
+        assert len(events) == 1
+        name, ok, _elapsed_ms, detail = events[0]
+        assert name == "get_quote"
+        assert ok is False
+        assert "超时" in detail
+
+
+class TestLLMRetry:
+    """LLM 调用的瞬时错误按指数退避重试；非瞬时错误立即抛出。"""
+
+    @patch("openai.OpenAI")
+    def test_rate_limit_retries_then_succeeds(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """429 限流 → 退避后重试成功。"""
+        svc = AgentService(mock_ctx, api_key="sk-test", retry_base_delay=0)
+        svc._client.chat.completions.create.side_effect = [
+            _rate_limit_err(),
+            _text_response("你好！"),
+        ]
+
+        with patch("time.sleep") as mock_sleep:
+            resp = svc.chat("你好")
+
+        assert resp.text == "你好！"
+        assert svc._client.chat.completions.create.call_count == 2
+        assert mock_sleep.call_count == 1
+
+    @patch("openai.OpenAI")
+    def test_retry_exhaustion_raises(self, _mock_openai: MagicMock, mock_ctx: ToolContext) -> None:
+        """持续连接失败：重试 max_retries 次后抛出最后一次异常。"""
+        svc = AgentService(mock_ctx, api_key="sk-test", max_retries=2, retry_base_delay=0)
+        svc._client.chat.completions.create.side_effect = _conn_err()
+
+        with patch("time.sleep"), pytest.raises(APIConnectionError):
+            svc.chat("你好")
+
+        # 1 次原始调用 + 2 次重试
+        assert svc._client.chat.completions.create.call_count == 3
+
+    @patch("openai.OpenAI")
+    def test_non_retryable_error_raises_immediately(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """400 参数错误不属于瞬时错误，不重试、不退避，直接抛出。"""
+        svc = AgentService(mock_ctx, api_key="sk-test", retry_base_delay=0)
+        bad_req = BadRequestError(
+            "invalid messages", response=httpx.Response(400, request=_request()), body=None
+        )
+        svc._client.chat.completions.create.side_effect = bad_req
+
+        with patch("time.sleep") as mock_sleep, pytest.raises(BadRequestError):
+            svc.chat("你好")
+
+        assert svc._client.chat.completions.create.call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
## 改动描述

强化 `AgentService._run_loop` 的容错能力，改动集中在 `src/mommy_chaogu/agent/service.py`：

1. **工具异常恢复**：工具执行抛异常时不再 `raise` 中断整轮对话，而是把错误序列化为 `{"error": "工具执行异常: ..."}` 作为 tool 消息回传给 LLM，由 LLM 决定换工具重试或在回答中向用户说明降级原因。`on_tool_result` 回调仍以 `ok=False` 触发，TUI 的工具失败渲染（ToolIndicator）不受影响。
2. **LLM 调用重试**：新增 `_create_with_retry`，对瞬时错误（连接错误 `APIConnectionError` / 429 限流 `RateLimitError` / 5xx `InternalServerError`）按指数退避重试（`base * 2^attempt + jitter`），默认重试 3 次。认证、参数等非瞬时错误不重试，立即抛出。重试次数与基础间隔通过新构造参数 `max_retries` / `retry_base_delay` 可配。

## 为什么

- 数据源（东财 / 腾讯）是抓取型三方接口，临时超时或限流是常态。此前 `_run_loop` 中 `self._tools.call()` 一旦抛异常就直接向上传播，用户整个提问作废——虽然默认 `ToolRegistry.call` 内部有兜底，但 service 层不应把「registry 永远不抛异常」作为隐式契约。
- 此前 LLM 调用裸奔，一次网络抖动或 429 就是一次失败的对话。上游 CLI / TUI 虽有 try/except 兜底展示，但瞬时错误本可通过退避重试自愈。

## 怎么验证

- [x] 单元测试已添加（`tests/test_agent/test_service_resilience.py`，6 个用例）
- [x] 手动测试通过
- [x] 没有破坏现有功能

### 验证命令 / 输出

```bash
$ uv run pytest tests/test_agent/test_service_resilience.py tests/test_agent/test_service.py -q
..................                                                       [100%]
# 18 passed（新增 6 + 既有 12）

$ uv run pytest -m "not network"
1 failed, 1126 passed, 13 deselected in 19.25s
# 唯一失败为 test_vector_search.py::TestSearchSimilar::test_search_returns_results，
# 系 main 上预先存在的 sqlite-vec 版本行为问题（vec0 knn 查询要求 LIMIT/k 约束），
# 与本 PR 无关，本地环境可复现于未改动的 main。
```

新增用例覆盖：
- 工具抛异常 → 整轮不炸，LLM 收到 `{"error": ...}` tool 消息并降级回答
- 工具异常时 `on_tool_result` 以 `ok=False` 触发（TUI 渲染契约）
- 429 限流 → 退避一次后成功
- 持续连接失败 → 重试耗尽后抛最后一次异常（1 + max_retries 次调用）
- 400 参数错误 → 不重试、不退避，立即抛出

## 质量门

- [x] `uv run ruff format .` 无 diff
- [x] `uv run ruff check .` 无 errors
- [x] `uv run mypy --strict src` 无 errors（147 个源文件）
- [x] `uv run pytest -m "not network"` 全过（除上述 main 上既有失败）

## 检查清单

- [x] 代码风格符合 [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] 新功能有对应测试
- [x] commit message 符合 Conventional Commits 格式
- [x] 文档已更新（模块 docstring 补充容错行为说明）

## 关联 Issue

Related to 项目 review 中提出的 agent 循环容错问题（工具异常炸整轮 + LLM 调用无重试）。

## 截图 / 日志

无。