### PR TITLE
feat: 二档体验深化 — 真流式 + Esc 取消 + token 统计 + slash 卡片 + 预测页（#4-#9）

### DIFF
--- a/src/mommy_chaogu/agent/service.py
+++ b/src/mommy_chaogu/agent/service.py
@@ -186,6 +186,7 @@ class AgentService:
         on_tool_result: Callable[[str, bool, int, str], None] | None = None,
         on_chunk: Callable[[str], None] | None = None,
         cancel_event: threading.Event | None = None,
+        usage_out: dict[str, int] | None = None,
     ) -> AgentResponse:
         """单轮对话（可带历史），返回最终文本 + 工具调用日志。
 
@@ -199,8 +200,13 @@ class AgentService:
           逐 delta 调 on_chunk；provider 不支持 stream 时自动回退非流式。
 
         取消：
-        - 如果传入 *cancel_event*，每轮 LLM 调用前 + 每个工具执行前检查 is_set()，
-          命中即立即返回 interrupted=True。
+        - 如果传入 *cancel_event*，每轮 LLM 调用前 + 每个工具执行前 + 流式输出途中
+          检查 is_set()，命中即立即返回 interrupted=True。
+
+        token 统计：
+        - 如果传入 *usage_out*，它会被直接用作累加容器（worker 线程原地累加），
+          调用方可在对话进行中实时读取——TUI 的 WorkingIndicator 靠它显示
+          实时 token 数。resp.usage 与 usage_out 是同一个 dict。
         """
         ms = self._memory_service
 
@@ -235,6 +241,7 @@ class AgentService:
             on_tool_result=on_tool_result,
             on_chunk=on_chunk,
             cancel_event=cancel_event,
+            usage_out=usage_out,
         )
 
         # 3. 对话后记录 + 提取
@@ -258,6 +265,7 @@ class AgentService:
         on_tool_result: Callable[[str, bool, int, str], None] | None = None,
         on_chunk: Callable[[str], None] | None = None,
         cancel_event: threading.Event | None = None,
+        usage_out: dict[str, int] | None = None,
     ) -> AgentResponse:
         """直接传入完整 messages 列表（灵活但需自己构造格式）。"""
         return self._run_loop(
@@ -266,6 +274,7 @@ class AgentService:
             on_tool_result=on_tool_result,
             on_chunk=on_chunk,
             cancel_event=cancel_event,
+            usage_out=usage_out,
         )
 
     def _create_with_retry(self, messages: list[dict[str, Any]]) -> Any:
@@ -308,6 +317,7 @@ class AgentService:
         on_tool_result: Callable[[str, bool, int, str], None] | None = None,
         on_chunk: Callable[[str], None] | None = None,
         cancel_event: threading.Event | None = None,
+        usage_out: dict[str, int] | None = None,
     ) -> AgentResponse:
         """核心 agent 循环：LLM → tool_calls → execute → LLM → ...
 
@@ -318,12 +328,15 @@ class AgentService:
         on_chunk：工具循环结束后，若有则发起一次 stream=True 的最终回答调用，
         逐 delta 调用。provider 不支持 stream 时回退非流式。
 
-        cancel_event：每轮 LLM 调用前 + 每个工具执行前检查 is_set()，
-        命中即返回 interrupted=True 的 AgentResponse。
+        cancel_event：每轮 LLM 调用前 + 每个工具执行前 + 流式输出途中检查
+        is_set()，命中即返回 interrupted=True 的 AgentResponse。
+
+        usage_out：若提供，直接作为 usage 累加容器（引用共享），调用方可在
+        对话进行中实时读取累加值；AgentResponse.usage 即此 dict。
         """
         all_tool_calls: list[ToolCallRecord] = []
         rounds = 0
-        total_usage: dict[str, int] = {}
+        total_usage: dict[str, int] = usage_out if usage_out is not None else {}
 
         while rounds < self._max_tool_calls:
             # 取消检查（每轮 LLM 调用前）
@@ -350,11 +363,19 @@ class AgentService:
                 # 仅在 on_chunk 提供时启用；provider 不支持 stream 或失败时
                 # _stream_final_answer 返回 None，保留非流式 text 兜底。
                 if on_chunk is not None and text:
-                    streamed = self._stream_final_answer(
-                        messages, on_chunk, cancel_event, total_usage
-                    )
+                    streamed = self._stream_final_answer(messages, on_chunk, cancel_event)
                     if streamed is not None:
                         text = streamed
+                # 流式输出途中被取消：已流出的部分保留，但标记 interrupted，
+                # 让 UI 层按「已中断」而非「完整回答」收尾。
+                if cancel_event is not None and cancel_event.is_set():
+                    return AgentResponse(
+                        text=text or "（已中断）",
+                        tool_calls=all_tool_calls,
+                        rounds=rounds,
+                        usage=total_usage,
+                        interrupted=True,
+                    )
                 return AgentResponse(
                     text=text,
                     tool_calls=all_tool_calls,
@@ -459,12 +480,14 @@ class AgentService:
         messages: list[dict[str, Any]],
         on_chunk: Callable[[str], None],
         cancel_event: threading.Event | None,
-        total_usage: dict[str, int],
     ) -> str | None:
         """发起一次 stream=True 的无 tools 调用，逐 delta 调 on_chunk。
 
         学 dexter：工具循环已由上一轮非流式调用得出最终回答方向，这里重新发
         一次相同 messages 的流式调用（不绑 tools），把完整文本流式输出给前端。
+
+        注意：流式调用的 usage 不累加——最终回答的 token 成本只计上一轮
+        非流式调用那一次，避免同一回答被计两次、统计口径虚高。
 
         返回 None 表示流式不可用（provider 不支持或出错），调用方用上一轮
         非流式 text 兜底；返回 str 为实际流式收集到的完整文本。
@@ -493,8 +516,6 @@ class AgentService:
                     collected.append(text)
                     with contextlib.suppress(Exception):
                         on_chunk(text)
-                # 流式 usage（部分 provider 在最后一个 chunk 带 usage）
-                self._accumulate_usage(total_usage, chunk)
         except Exception as exc:
             _log.warning("stream 迭代中断: %s", exc)
             # 已收集的部分仍有价值，返回已得文本（可能不完整）

--- a/src/mommy_chaogu/agent/service.py
+++ b/src/mommy_chaogu/agent/service.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import random
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -93,6 +94,8 @@ class AgentResponse:
     text: str
     tool_calls: list[ToolCallRecord] = field(default_factory=list)
     rounds: int = 0  # LLM 调用轮数
+    usage: dict[str, int] = field(default_factory=dict)  # prompt/completion/total tokens
+    interrupted: bool = False  # 被 cancel_event 中断
 
 
 class AgentService:
@@ -181,6 +184,8 @@ class AgentService:
         memory: ConversationMemoryLike | None = None,
         on_tool_call: Callable[[str, dict[str, Any]], None] | None = None,
         on_tool_result: Callable[[str, bool, int, str], None] | None = None,
+        on_chunk: Callable[[str], None] | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> AgentResponse:
         """单轮对话（可带历史），返回最终文本 + 工具调用日志。
 
@@ -188,6 +193,14 @@ class AgentService:
         - 如果传入 *memory*，用它做跨轮次对话上下文 + 持久化
         - 如果 *memory_service* 存在（构造时传入），对话前注入历史事件/预测/知识，
           对话后提取 observations/predictions
+
+        流式：
+        - 如果传入 *on_chunk*，工具循环结束后会发起一次 stream=True 的最终回答调用，
+          逐 delta 调 on_chunk；provider 不支持 stream 时自动回退非流式。
+
+        取消：
+        - 如果传入 *cancel_event*，每轮 LLM 调用前 + 每个工具执行前检查 is_set()，
+          命中即立即返回 interrupted=True。
         """
         ms = self._memory_service
 
@@ -216,7 +229,13 @@ class AgentService:
 
         messages.append({"role": "user", "content": user_message})
 
-        resp = self._run_loop(messages, on_tool_call=on_tool_call, on_tool_result=on_tool_result)
+        resp = self._run_loop(
+            messages,
+            on_tool_call=on_tool_call,
+            on_tool_result=on_tool_result,
+            on_chunk=on_chunk,
+            cancel_event=cancel_event,
+        )
 
         # 3. 对话后记录 + 提取
         adapter = self._ctx.adapter if self._ctx else None
@@ -237,9 +256,17 @@ class AgentService:
         messages: list[dict[str, Any]],
         on_tool_call: Callable[[str, dict[str, Any]], None] | None = None,
         on_tool_result: Callable[[str, bool, int, str], None] | None = None,
+        on_chunk: Callable[[str], None] | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> AgentResponse:
         """直接传入完整 messages 列表（灵活但需自己构造格式）。"""
-        return self._run_loop(messages, on_tool_call=on_tool_call, on_tool_result=on_tool_result)
+        return self._run_loop(
+            messages,
+            on_tool_call=on_tool_call,
+            on_tool_result=on_tool_result,
+            on_chunk=on_chunk,
+            cancel_event=cancel_event,
+        )
 
     def _create_with_retry(self, messages: list[dict[str, Any]]) -> Any:
         """调用 LLM，对瞬时错误（连接 / 限流 / 5xx）按指数退避重试。
@@ -279,29 +306,60 @@ class AgentService:
         messages: list[dict[str, Any]],
         on_tool_call: Callable[[str, dict[str, Any]], None] | None = None,
         on_tool_result: Callable[[str, bool, int, str], None] | None = None,
+        on_chunk: Callable[[str], None] | None = None,
+        cancel_event: threading.Event | None = None,
     ) -> AgentResponse:
         """核心 agent 循环：LLM → tool_calls → execute → LLM → ...
 
         on_tool_call 在每次工具执行前触发；on_tool_result 在执行后触发，
         签名为 (fn_name, ok, elapsed_ms, result_or_error)——TUI 用它做
         dexter 风格的 tool_start/tool_end 实时渲染。
+
+        on_chunk：工具循环结束后，若有则发起一次 stream=True 的最终回答调用，
+        逐 delta 调用。provider 不支持 stream 时回退非流式。
+
+        cancel_event：每轮 LLM 调用前 + 每个工具执行前检查 is_set()，
+        命中即返回 interrupted=True 的 AgentResponse。
         """
         all_tool_calls: list[ToolCallRecord] = []
         rounds = 0
+        total_usage: dict[str, int] = {}
 
         while rounds < self._max_tool_calls:
+            # 取消检查（每轮 LLM 调用前）
+            if cancel_event is not None and cancel_event.is_set():
+                return AgentResponse(
+                    text="（已中断）",
+                    tool_calls=all_tool_calls,
+                    rounds=rounds,
+                    usage=total_usage,
+                    interrupted=True,
+                )
+
             rounds += 1
 
             response = self._create_with_retry(messages)
+            self._accumulate_usage(total_usage, response)
 
             msg = response.choices[0].message
 
             # 如果没有 tool_calls，说明 LLM 已经准备好回复
             if not msg.tool_calls:
+                text = msg.content or ""
+                # 流式最终回答：发起一次 stream=True 调用以逐 delta 输出。
+                # 仅在 on_chunk 提供时启用；provider 不支持 stream 或失败时
+                # _stream_final_answer 返回 None，保留非流式 text 兜底。
+                if on_chunk is not None and text:
+                    streamed = self._stream_final_answer(
+                        messages, on_chunk, cancel_event, total_usage
+                    )
+                    if streamed is not None:
+                        text = streamed
                 return AgentResponse(
-                    text=msg.content or "",
+                    text=text,
                     tool_calls=all_tool_calls,
                     rounds=rounds,
+                    usage=total_usage,
                 )
 
             # 把 LLM 的 tool_call 消息加入历史
@@ -309,6 +367,16 @@ class AgentService:
 
             # 执行每个 tool_call
             for tc in msg.tool_calls:
+                # 取消检查（每个工具执行前）
+                if cancel_event is not None and cancel_event.is_set():
+                    return AgentResponse(
+                        text="（已中断）",
+                        tool_calls=all_tool_calls,
+                        rounds=rounds,
+                        usage=total_usage,
+                        interrupted=True,
+                    )
+
                 fn_name = tc.function.name
                 try:
                     fn_args = json.loads(tc.function.arguments)
@@ -368,7 +436,69 @@ class AgentService:
             text="（分析过程中工具调用次数过多，请缩小问题范围后重试）",
             tool_calls=all_tool_calls,
             rounds=rounds,
+            usage=total_usage,
         )
+
+    # ------------------------------------------------------------------
+    # 流式 + usage 辅助
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _accumulate_usage(total: dict[str, int], response: Any) -> None:
+        """把单次 response.usage 累加到 total dict。"""
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return
+        for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+            val = getattr(usage, key, None)
+            if val is not None:
+                total[key] = total.get(key, 0) + int(val)
+
+    def _stream_final_answer(
+        self,
+        messages: list[dict[str, Any]],
+        on_chunk: Callable[[str], None],
+        cancel_event: threading.Event | None,
+        total_usage: dict[str, int],
+    ) -> str | None:
+        """发起一次 stream=True 的无 tools 调用，逐 delta 调 on_chunk。
+
+        学 dexter：工具循环已由上一轮非流式调用得出最终回答方向，这里重新发
+        一次相同 messages 的流式调用（不绑 tools），把完整文本流式输出给前端。
+
+        返回 None 表示流式不可用（provider 不支持或出错），调用方用上一轮
+        非流式 text 兜底；返回 str 为实际流式收集到的完整文本。
+        """
+        try:
+            stream = self._client.chat.completions.create(
+                model=self._model,
+                messages=messages,
+                stream=True,
+                **self._completion_options,
+            )
+        except Exception as exc:
+            _log.warning("stream 调用失败，回退非流式: %s", exc)
+            return None
+
+        collected: list[str] = []
+        try:
+            for chunk in stream:
+                if cancel_event is not None and cancel_event.is_set():
+                    break
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                text = getattr(delta, "content", None)
+                if text:
+                    collected.append(text)
+                    with contextlib.suppress(Exception):
+                        on_chunk(text)
+                # 流式 usage（部分 provider 在最后一个 chunk 带 usage）
+                self._accumulate_usage(total_usage, chunk)
+        except Exception as exc:
+            _log.warning("stream 迭代中断: %s", exc)
+            # 已收集的部分仍有价值，返回已得文本（可能不完整）
+        return "".join(collected)
 
     @property
     def tools(self) -> ToolRegistry:

--- a/src/mommy_chaogu/tui/app.py
+++ b/src/mommy_chaogu/tui/app.py
@@ -13,6 +13,7 @@ import argparse
 import contextlib
 import logging
 import os
+import threading
 import time
 from collections import defaultdict, deque
 from typing import Any, ClassVar
@@ -130,6 +131,10 @@ class MommyTuiApp(App[None]):
         self._turn_started: float = 0.0
         self._tool_seq: int = 0
         self._pending_tool_ids: dict[str, deque[int]] = defaultdict(deque)
+        # 流式 + 取消状态（每个 turn 重置）
+        self._cancel_event: threading.Event | None = None
+        self._stream_usage: dict[str, int] = {}
+        self._stream_flush_timer: Any = None
 
     def compose(self) -> ComposeResult:
         """挂载主屏。"""
@@ -231,6 +236,11 @@ class MommyTuiApp(App[None]):
         chat.set_busy(True)
         self._turn_started = time.monotonic()
 
+        # 每轮重置 cancel + usage 状态
+        self._cancel_event = threading.Event()
+        self._stream_usage = {}
+        chat.set_cancel_callback(self._cancel_event.set)
+
         # 1. 尝试工作流路由
         route = self.services.agent.route(text)
         if route is not None and getattr(route, "matched", False):
@@ -320,7 +330,12 @@ class MommyTuiApp(App[None]):
     # ------------------------------------------------------------------
 
     def _do_agent_chat(self, text: str) -> None:
-        """worker 线程内调用 agent.chat，工具调用/结果实时回传 UI。"""
+        """worker 线程内调用 agent.chat，工具调用/结果 + 流式 chunk 实时回传 UI。
+
+        #4 流式：on_chunk 回调把每个 delta 转发到 ChatView 的流式 widget。
+        #5 取消：cancel_event 在 worker 开始前创建，Esc 时 set()。
+        #6 token：usage 由 agent 层累加，worker 结束后传给 finish_turn。
+        """
 
         def on_tool_call(fn_name: str, fn_args: dict[str, Any]) -> None:
             self.call_from_thread(self._post_tool_started, fn_name, fn_args)
@@ -328,19 +343,37 @@ class MommyTuiApp(App[None]):
         def on_tool_result(fn_name: str, ok: bool, elapsed_ms: int, result: str) -> None:
             self.call_from_thread(self._post_tool_result, fn_name, ok, elapsed_ms, result)
 
+        # 流式 chunk 回调：worker 线程调用，通过 call_from_thread 转主线程
+        streaming_started = threading.Event()
+
+        def on_chunk(delta: str) -> None:
+            if not streaming_started.is_set():
+                streaming_started.set()
+                self.call_from_thread(self._start_streaming)
+
+            self.call_from_thread(self._append_stream_chunk, delta)
+
         try:
             resp = self.services.agent.chat(
-                text, on_tool_call=on_tool_call, on_tool_result=on_tool_result
+                text,
+                on_tool_call=on_tool_call,
+                on_tool_result=on_tool_result,
+                on_chunk=on_chunk,
+                cancel_event=self._cancel_event,
             )
         except Exception as e:
             _log.warning("Agent chat 失败: %s", e)
             self.call_from_thread(self._on_chat_error, f"Agent 出错：{e}")
             return
 
+        # 收集 usage（#6）
+        usage = getattr(resp, "usage", {}) if resp is not None else {}
+        interrupted = getattr(resp, "interrupted", False) if resp is not None else False
         reply = ""
         if resp is not None:
             reply = getattr(resp, "text", "") or ""
-        self.call_from_thread(self._on_agent_done, reply)
+
+        self.call_from_thread(self._on_agent_done, reply, interrupted, usage)
 
     def _post_tool_started(self, name: str, args: dict[str, Any]) -> None:
         """主线程：分配 call_id 并通知 ChatView 挂载 ToolIndicator。"""
@@ -359,22 +392,76 @@ class MommyTuiApp(App[None]):
         chat = self.query_one(ChatView)
         chat.tool_call_finished(call_id, ok, elapsed_ms, result)
 
+    def _start_streaming(self) -> None:
+        """主线程：首个 chunk 到达时挂载流式 widget + 启动 50ms 节流 timer。"""
+        chat = self.query_one(ChatView)
+        chat.start_streaming()
+        # 注册 usage 共享 dict 给 WorkingIndicator 做 token 统计
+        if chat._working is not None:
+            chat._working.set_stats_provider(lambda: self._stream_usage)
+        # 50ms 节流 timer（在主线程刷新 Markdown）
+        self._stream_flush_timer = self.set_timer(0.05, self._flush_stream_loop)
+
+    def _flush_stream_loop(self) -> None:
+        """主线程：节流刷新流式 Markdown，循环直到流式结束。"""
+        chat = self.query_one(ChatView)
+        chat.flush_stream()
+        # 如果流式 widget 还在，继续调度下一次刷新
+        if chat._stream_widget is not None:
+            self._stream_flush_timer = self.set_timer(0.05, self._flush_stream_loop)
+        else:
+            self._stream_flush_timer = None
+
+    def _append_stream_chunk(self, delta: str) -> None:
+        """主线程：追加一个 chunk 到 ChatView 缓冲区。"""
+        chat = self.query_one(ChatView)
+        chat.append_chunk(delta)
+
     def _turn_elapsed_ms(self) -> int:
         if self._turn_started <= 0:
             return 0
         return int((time.monotonic() - self._turn_started) * 1000)
 
-    def _on_agent_done(self, reply: str) -> None:
+    def _on_agent_done(
+        self, reply: str, interrupted: bool = False, usage: dict[str, int] | None = None
+    ) -> None:
         """主线程：Agent 回复完成。"""
+        self._stream_usage = usage or {}
         chat = self.query_one(ChatView)
-        if chat.is_cancelled():
+
+        # 如果流式 widget 存在，收尾它（最终刷新 + 拿到流式文本）
+        streamed_text = ""
+        if chat._stream_widget is not None:
+            streamed_text = chat.finalize_stream()
+        # 停止 flush timer（如果还在跑）
+        if self._stream_flush_timer is not None:
+            self._stream_flush_timer.stop()
+            self._stream_flush_timer = None
+
+        if interrupted:
+            # Esc 真取消：action_cancel_chat 已显示"已中断"，这里只收尾 busy
             chat.clear_cancelled()
             chat.set_busy(False)
             return
-        text = reply if reply else "（无回复）"
-        chat.append_assistant(text)
+
+        if chat.is_cancelled():
+            # UI 取消（旧路径兼容）
+            chat.clear_cancelled()
+            chat.set_busy(False)
+            return
+
+        # 如果有流式文本，流式 widget 已渲染了它（不需要再 append_assistant）；
+        # 否则用非流式 reply 走 append_assistant。
+        text = streamed_text or reply
+        if not streamed_text:
+            chat.append_assistant(text if text else "（无回复）")
         chat.set_busy(False)
-        chat.finish_turn(self._turn_elapsed_ms())
+
+        # token 统计（#6）：优先 total_tokens，否则 completion_tokens
+        tokens = self._stream_usage.get("total_tokens") or self._stream_usage.get(
+            "completion_tokens", 0
+        )
+        chat.finish_turn(self._turn_elapsed_ms(), tokens=tokens)
 
     def _on_chat_error(self, error: str) -> None:
         """主线程：对话出错。"""

--- a/src/mommy_chaogu/tui/app.py
+++ b/src/mommy_chaogu/tui/app.py
@@ -133,6 +133,8 @@ class MommyTuiApp(App[None]):
         self._pending_tool_ids: dict[str, deque[int]] = defaultdict(deque)
         # 流式 + 取消状态（每个 turn 重置）
         self._cancel_event: threading.Event | None = None
+        # usage 共享 dict：作为 usage_out 传给 agent 层，worker 线程原地累加，
+        # WorkingIndicator 的 stats_provider 在主线程实时读它。
         self._stream_usage: dict[str, int] = {}
         self._stream_flush_timer: Any = None
 
@@ -334,7 +336,8 @@ class MommyTuiApp(App[None]):
 
         #4 流式：on_chunk 回调把每个 delta 转发到 ChatView 的流式 widget。
         #5 取消：cancel_event 在 worker 开始前创建，Esc 时 set()。
-        #6 token：usage 由 agent 层累加，worker 结束后传给 finish_turn。
+        #6 token：self._stream_usage 作为 usage_out 共享 dict 传入，agent 层
+           原地累加，主线程 WorkingIndicator 的 stats_provider 实时读取。
         """
 
         def on_tool_call(fn_name: str, fn_args: dict[str, Any]) -> None:
@@ -360,13 +363,15 @@ class MommyTuiApp(App[None]):
                 on_tool_result=on_tool_result,
                 on_chunk=on_chunk,
                 cancel_event=self._cancel_event,
+                usage_out=self._stream_usage,
             )
         except Exception as e:
             _log.warning("Agent chat 失败: %s", e)
             self.call_from_thread(self._on_chat_error, f"Agent 出错：{e}")
             return
 
-        # 收集 usage（#6）
+        # 收集 usage（#6）：resp.usage 与 self._stream_usage 是同一 dict，
+        # 但 resp 可能为 None（AgentBridge 未配置），这里仍走 getattr 兼容。
         usage = getattr(resp, "usage", {}) if resp is not None else {}
         interrupted = getattr(resp, "interrupted", False) if resp is not None else False
         reply = ""
@@ -396,7 +401,9 @@ class MommyTuiApp(App[None]):
         """主线程：首个 chunk 到达时挂载流式 widget + 启动 50ms 节流 timer。"""
         chat = self.query_one(ChatView)
         chat.start_streaming()
-        # 注册 usage 共享 dict 给 WorkingIndicator 做 token 统计
+        # 注册 usage 共享 dict 给 WorkingIndicator 做实时 token 统计。
+        # self._stream_usage 已作为 usage_out 传给 agent 层，worker 线程在
+        # 每轮 LLM 返回后原地累加，这里读到的就是实时值。
         if chat._working is not None:
             chat._working.set_stats_provider(lambda: self._stream_usage)
         # 50ms 节流 timer（在主线程刷新 Markdown）

--- a/src/mommy_chaogu/tui/messages.py
+++ b/src/mommy_chaogu/tui/messages.py
@@ -1,11 +1,17 @@
 """TUI 消息协议（§5.4）。
 
-跨 widget 通信一律走 Textual Message，禁止 widget 间直接方法调用。
+现状说明：跨 widget 通信目前实际有两条路径——
 
-注：原设计中还有 AgentChunk / ToolCallStarted / ToolCallFinished / AgentDone
-等消息，但实际实现走 app.call_from_thread → ChatView 直接方法调用（worker
-线程 → 主线程），这些消息从未被发送。清理见 PLAN.md 三档 #9。
-实际使用的只剩 StepStatus（工作流步骤进度，由 _post_step 发送）。
+1. worker 线程 → 主线程：app.call_from_thread → ChatView 直接方法调用
+   （工具指示器、流式 chunk、turn 收尾都走这条，见 app.py）。
+2. 主线程内 widget 间：Textual Message。
+
+原设计中 AgentChunk / ToolCallStarted / ToolCallFinished / AgentDone 等
+消息从未被实际发送（路径 1 取代了它们），已在 PLAN.md 三档 #9 清理。
+目前真正使用的只剩 StepStatus（工作流步骤进度，由 _post_step 发送）。
+
+新增跨 widget 通信时：worker 线程回 UI 用 call_from_thread，主线程内
+才用 Message——不要照已被清理的旧设计恢复消息类。
 """
 
 from __future__ import annotations

--- a/src/mommy_chaogu/tui/messages.py
+++ b/src/mommy_chaogu/tui/messages.py
@@ -1,71 +1,16 @@
 """TUI 消息协议（§5.4）。
 
 跨 widget 通信一律走 Textual Message，禁止 widget 间直接方法调用。
+
+注：原设计中还有 AgentChunk / ToolCallStarted / ToolCallFinished / AgentDone
+等消息，但实际实现走 app.call_from_thread → ChatView 直接方法调用（worker
+线程 → 主线程），这些消息从未被发送。清理见 PLAN.md 三档 #9。
+实际使用的只剩 StepStatus（工作流步骤进度，由 _post_step 发送）。
 """
 
 from __future__ import annotations
 
-from typing import Any
-
 from textual.message import Message
-
-
-class QuotesUpdated(Message):
-    """自选股报价更新。"""
-
-    def __init__(self, rows: list[dict[str, Any]], source_label: str, ts: float) -> None:
-        super().__init__()
-        self.rows = rows
-        self.source_label = source_label
-        self.ts = ts
-
-
-class PortfolioUpdated(Message):
-    """持仓更新。"""
-
-    def __init__(self, summary: dict[str, Any], rows: list[dict[str, Any]]) -> None:
-        super().__init__()
-        self.summary = summary
-        self.rows = rows
-
-
-class SectorsUpdated(Message):
-    """板块排行更新。"""
-
-    def __init__(self, rows: list[dict[str, Any]]) -> None:
-        super().__init__()
-        self.rows = rows
-
-
-class SignalFired(Message):
-    """信号触发。"""
-
-    def __init__(
-        self,
-        code: str,
-        name: str,
-        rule: str,
-        value: str,
-        severity: str,
-        ts: str,
-    ) -> None:
-        super().__init__()
-        self.code = code
-        self.name = name
-        self.rule = rule
-        self.value = value
-        self.severity = severity
-        self.ts = ts
-
-
-class WorkflowMatched(Message):
-    """工作流匹配成功。"""
-
-    def __init__(self, workflow_id: str, title: str, steps: list[str]) -> None:
-        super().__init__()
-        self.workflow_id = workflow_id
-        self.title = title
-        self.steps = steps
 
 
 class StepStatus(Message):
@@ -76,50 +21,3 @@ class StepStatus(Message):
         self.idx = idx
         self.state = state  # running | ok | fail
         self.detail = detail
-
-
-class AgentChunk(Message):
-    """Agent 流式输出片段。"""
-
-    def __init__(self, delta: str) -> None:
-        super().__init__()
-        self.delta = delta
-
-
-class ToolCallStarted(Message):
-    """工具调用开始。"""
-
-    def __init__(self, call_id: int, name: str, args: dict[str, Any]) -> None:
-        super().__init__()
-        self.call_id = call_id
-        self.name = name
-        self.args = args
-
-
-class ToolCallFinished(Message):
-    """工具调用完成。"""
-
-    def __init__(self, call_id: int, ok: bool, elapsed_ms: int, result_digest: str) -> None:
-        super().__init__()
-        self.call_id = call_id
-        self.ok = ok
-        self.elapsed_ms = elapsed_ms
-        self.result_digest = result_digest
-
-
-class AgentDone(Message):
-    """Agent 回复完成。"""
-
-    def __init__(self, tools_used: int, interrupted: bool = False) -> None:
-        super().__init__()
-        self.tools_used = tools_used
-        self.interrupted = interrupted
-
-
-class ConnectionChanged(Message):
-    """连接状态变更。"""
-
-    def __init__(self, level: str, source_label: str) -> None:
-        super().__init__()
-        self.level = level  # live | degraded | offline
-        self.source_label = source_label

--- a/src/mommy_chaogu/tui/services/bootstrap.py
+++ b/src/mommy_chaogu/tui/services/bootstrap.py
@@ -129,11 +129,18 @@ class AgentBridge:
         history: list[dict[str, str]] | None = None,
         on_tool_call: Any = None,
         on_tool_result: Any = None,
+        on_chunk: Any = None,
+        cancel_event: Any = None,
     ) -> Any:
         if self._agent is None:
             return None
         return self._agent.chat(
-            message, history=history, on_tool_call=on_tool_call, on_tool_result=on_tool_result
+            message,
+            history=history,
+            on_tool_call=on_tool_call,
+            on_tool_result=on_tool_result,
+            on_chunk=on_chunk,
+            cancel_event=cancel_event,
         )
 
 
@@ -143,6 +150,8 @@ class Services:
 
     data: DataService = field(default_factory=DataService)
     agent: AgentBridge = field(default_factory=AgentBridge)
+    flows: Any = None  # FlowService，无 MARKET_DB 退化为 None
+    memory_db: Any = None  # 记忆统计可调用字典（见 _make_memory_stats）
 
     @classmethod
     def bootstrap(cls) -> Services:
@@ -228,7 +237,39 @@ class Services:
         except Exception as e:
             _log.warning("NLRouter 初始化失败: %s", e)
 
-        return cls(data=data_svc, agent=agent_bridge)
+        # FlowService（/flows slash 命令用）
+        flows_service = None
+        try:
+            from mommy_chaogu.flows.service import FlowService
+
+            flows_service = FlowService.from_default(MARKET_DB)
+        except Exception as e:
+            _log.warning("FlowService 初始化失败: %s", e)
+
+        # 记忆统计可调用（/memory slash 命令用，无 api_key 也能查统计）
+        memory_stats = _make_memory_stats(AGENT_DB)
+
+        return cls(data=data_svc, agent=agent_bridge, flows=flows_service, memory_db=memory_stats)
+
+
+def _make_memory_stats(agent_db: Any) -> dict[str, Any] | None:
+    """构造记忆统计 dict（含各 summary()/stats() 调用器）。
+
+    返回 None 表示记忆系统不可用（db 初始化失败）。
+    """
+    try:
+        from mommy_chaogu.agent.episodic_memory import EpisodicMemory
+        from mommy_chaogu.agent.prediction_tracker import PredictionTracker
+        from mommy_chaogu.agent.semantic_memory import SemanticMemory
+
+        return {
+            "episodic": EpisodicMemory(agent_db).summary,
+            "predictions": PredictionTracker(agent_db).stats,
+            "semantic": SemanticMemory(agent_db).summary,
+        }
+    except Exception as e:
+        _log.warning("记忆统计初始化失败: %s", e)
+        return None
 
 
 @dataclass
@@ -237,6 +278,8 @@ class FakeServices:
 
     data: DataService = field(default_factory=DataService)
     agent: AgentBridge = field(default_factory=AgentBridge)
+    flows: Any = None
+    memory_db: Any = None
 
     @classmethod
     def create(cls) -> FakeServices:
@@ -281,4 +324,39 @@ class FakeServices:
                 "total_cost": Decimal("48800"),
             }
         )
-        return cls(data=data, agent=AgentBridge())
+
+        # Fake flows + memory（供 /flows /memory slash 命令测试）
+        from types import SimpleNamespace
+
+        fake_flows = SimpleNamespace(
+            show=lambda code, days=30: {
+                "code": code,
+                "today": SimpleNamespace(
+                    name="测试股",
+                    main_net=Decimal("100000000"),
+                    super_large_net=Decimal("60000000"),
+                    large_net=Decimal("40000000"),
+                    medium_net=Decimal("-20000000"),
+                    small_net=Decimal("-80000000"),
+                    main_net_ratio=Decimal("12.5"),
+                    sample_count=1,
+                    period="today",
+                    big_money_net=Decimal("100000000"),
+                ),
+                "history": None,
+                "history_days_cached": 0,
+            }
+        )
+        fake_memory_db = {
+            "episodic": lambda: {"total": 15, "by_type": {"signal": 8, "news": 7}},
+            "predictions": lambda: {
+                "total": 10,
+                "hit": 4,
+                "missed": 1,
+                "pending": 5,
+                "hit_rate": 0.8,
+            },
+            "semantic": lambda: {"total": 23, "active": 20},
+        }
+
+        return cls(data=data, agent=AgentBridge(), flows=fake_flows, memory_db=fake_memory_db)

--- a/src/mommy_chaogu/tui/services/bootstrap.py
+++ b/src/mommy_chaogu/tui/services/bootstrap.py
@@ -131,6 +131,7 @@ class AgentBridge:
         on_tool_result: Any = None,
         on_chunk: Any = None,
         cancel_event: Any = None,
+        usage_out: Any = None,
     ) -> Any:
         if self._agent is None:
             return None
@@ -141,6 +142,7 @@ class AgentBridge:
             on_tool_result=on_tool_result,
             on_chunk=on_chunk,
             cancel_event=cancel_event,
+            usage_out=usage_out,
         )
 
 

--- a/src/mommy_chaogu/tui/views/chat.py
+++ b/src/mommy_chaogu/tui/views/chat.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
@@ -99,6 +100,13 @@ def match_slash_commands(value: str) -> list[SlashCommand]:
     return [cmd for name, cmd in SLASH_COMMANDS.items() if name.startswith(typed)]
 
 
+def _format_tokens_compact(n: int) -> str:
+    """token 数 → dexter 风格紧凑显示（1.2k / 850）。"""
+    if n >= 1000:
+        return f"{n / 1000:.1f}k"
+    return str(n)
+
+
 def _build_welcome() -> str:
     """构建欢迎页文本（含预设问题列表）。"""
     lines = [
@@ -173,6 +181,12 @@ class ChatView(Vertical):
         self._step_widgets: dict[int, Static] = {}
         self._slash_matches: list[SlashCommand] = []
         self._slash_sel: int = 0
+        # 流式渲染状态
+        self._stream_widget: Markdown | None = None
+        self._stream_buffer: str = ""
+        self._stream_dirty: bool = False
+        # 取消回调（app.py 设置，Esc 触发真取消）
+        self._cancel_callback: Callable[[], None] | None = None
 
     def compose(self) -> ComposeResult:
         with VerticalScroll(id="chat-log"):
@@ -393,9 +407,23 @@ class ChatView(Vertical):
             if not args:
                 self.append_hint("用法: /flows <股票代码>，如 /flows 688981")
             else:
-                self.append_hint(f"查看 {args} 资金流请在终端运行: mommy flows show {args}")
+                services = getattr(app, "services", None)
+                flows_service = getattr(services, "flows", None) if services else None
+                if flows_service is None:
+                    self.append_hint("资金流服务未配置")
+                else:
+                    try:
+                        info = flows_service.show(args, days=30)
+                        self.append_flows_card(args, info)
+                    except Exception as e:
+                        self.append_hint(f"查询 {args} 资金流失败：{e}")
         elif cmd == "memory":
-            self.append_hint("查看记忆请在终端运行: mommy memory stats")
+            services = getattr(app, "services", None)
+            memory_stats = getattr(services, "memory_db", None) if services else None
+            if memory_stats is None:
+                self.append_hint("记忆系统未配置")
+            else:
+                self.append_memory_card(memory_stats)
         elif cmd == "quit":
             app.quit()  # type: ignore[attr-defined]
 
@@ -445,12 +473,16 @@ class ChatView(Vertical):
             indicator.set_error(digest, elapsed_ms)
         self.query_one("#chat-log", VerticalScroll).scroll_end(animate=False)
 
-    def finish_turn(self, elapsed_ms: int, interrupted: bool = False) -> None:
-        """一轮对话收尾：✻ 总耗时（dexter performance-stats 风格）。"""
+    def finish_turn(self, elapsed_ms: int, interrupted: bool = False, tokens: int = 0) -> None:
+        """一轮对话收尾：✻ 总耗时 + token（dexter performance-stats 风格）。"""
         if interrupted:
             return
+        parts = [format_elapsed(elapsed_ms)]
+        if tokens:
+            parts.append(f"↓ {_format_tokens_compact(tokens)} tokens")
+        suffix = " · ".join(parts)
         log = self.query_one("#chat-log", VerticalScroll)
-        log.mount(Static(f"[#8a8f98]✻ {format_elapsed(elapsed_ms)}[/]", classes="turn-stats"))
+        log.mount(Static(f"[#8a8f98]✻ {suffix}[/]", classes="turn-stats"))
         log.scroll_end(animate=False)
 
     def append_hint(self, text: str) -> None:
@@ -458,6 +490,134 @@ class ChatView(Vertical):
         log = self.query_one("#chat-log", VerticalScroll)
         log.mount(Static(f"[yellow]⚠[/] {text}", classes="hint-card"))
         log.scroll_end(animate=False)
+
+    def append_flows_card(self, code: str, info: Any) -> None:
+        """渲染资金流卡片（#7：/flows <code>）。
+
+        info 是 FlowService.show() 的返回 dict：
+        {today: FlowSummary|None, history: FlowSummary|None, history_days_cached: int}
+        """
+        from mommy_chaogu.tui.services.formatting import format_flow
+
+        today = info.get("today") if info else None
+        history = info.get("history") if info else None
+        days = info.get("history_days_cached", 0) if info else 0
+        name = getattr(today or history, "name", code)
+
+        if today is None and history is None:
+            self.append_hint(f"{code} 暂无资金流数据")
+            return
+
+        lines: list[str] = [f"[bold cyan]💰 {name}（{code}）资金流[/]"]
+
+        def _summary_line(label: str, fs: Any, period: str) -> str:
+            main = format_flow(getattr(fs, "main_net", None))
+            big = (
+                format_flow(getattr(fs, "big_money_net", None))
+                if hasattr(fs, "big_money_net")
+                else "—"
+            )
+            ratio = getattr(fs, "main_net_ratio", None)
+            ratio_str = f"{float(ratio):+.1f}%" if ratio is not None else "—"
+            return f"  {label}（{period}）  主力 {main}  超大+大单 {big}  占比 {ratio_str}"
+
+        if today is not None:
+            lines.append(_summary_line("今日", today, "today"))
+        if history is not None and days > 0:
+            lines.append(_summary_line(f"近{days}日", history, f"history:{days}d"))
+
+        lines.append(f"  [dim]详细：mommy flows show {code}[/]")
+
+        log = self.query_one("#chat-log", VerticalScroll)
+        log.mount(Static("\n".join(lines), classes="flows-card"))
+        log.scroll_end(animate=False)
+
+    def append_memory_card(self, stats: dict[str, Any]) -> None:
+        """渲染记忆系统统计卡片（#7：/memory）。
+
+        stats 是 memory_db dict：{episodic: callable, predictions: callable, semantic: callable}
+        """
+        lines: list[str] = ["[bold cyan]🧠 记忆系统[/]"]
+
+        try:
+            ep = stats["episodic"]() if stats.get("episodic") else None
+            if ep:
+                lines.append(
+                    f"  事件：{ep.get('total', 0)} 条（{', '.join(f'{k} {v}' for k, v in ep.get('by_type', {}).items())}）"
+                )
+        except Exception:
+            pass
+
+        try:
+            pred = stats["predictions"]() if stats.get("predictions") else None
+            if pred:
+                hit_rate = pred.get("hit_rate", 0)
+                hit_rate_str = f"{float(hit_rate):.0%}" if hit_rate else "—"
+                lines.append(
+                    f"  预测：{pred.get('total', 0)} 条  命中 {pred.get('hit', 0)}/{pred.get('hit', 0) + pred.get('missed', 0)}（{hit_rate_str}）  待验证 {pred.get('pending', 0)}"
+                )
+        except Exception:
+            pass
+
+        try:
+            sem = stats["semantic"]() if stats.get("semantic") else None
+            if sem:
+                lines.append(f"  知识：{sem.get('total', 0)} 条（活跃 {sem.get('active', 0)}）")
+        except Exception:
+            pass
+
+        lines.append("  [dim]详细：mommy memory events / mommy memory predictions[/]")
+
+        log = self.query_one("#chat-log", VerticalScroll)
+        log.mount(Static("\n".join(lines), classes="memory-card"))
+        log.scroll_end(animate=False)
+
+    # ------------------------------------------------------------------
+    # 流式渲染（#4：逐 delta 更新 Markdown，50ms 节流）
+    # ------------------------------------------------------------------
+
+    def start_streaming(self) -> None:
+        """挂载流式 Markdown widget（首个 chunk 到达前调用）。"""
+        if self._stream_widget is not None:
+            return
+        self._stream_buffer = ""
+        self._stream_dirty = False
+        widget = Markdown("⏺ …", classes="assistant-msg streaming")
+        self._stream_widget = widget
+        log = self.query_one("#chat-log", VerticalScroll)
+        log.mount(widget)
+        log.scroll_end(animate=False)
+
+    def append_chunk(self, delta: str) -> None:
+        """追加一个流式 chunk 到缓冲区，标记 dirty 等待节流刷新。"""
+        self._stream_buffer += delta
+        self._stream_dirty = True
+
+    def flush_stream(self) -> None:
+        """把缓冲区内容刷新到 Markdown widget（由 app.py 的 timer 节流调用）。"""
+        if not self._stream_dirty or self._stream_widget is None:
+            return
+        self._stream_dirty = False
+        text = self._stream_buffer.lstrip("\n")
+        self._stream_widget.update(f"⏺ {text}")
+        self.query_one("#chat-log", VerticalScroll).scroll_end(animate=False)
+
+    def finalize_stream(self) -> str:
+        """收尾流式 widget：最终刷新并返回完整文本。"""
+        self.flush_stream()
+        widget = self._stream_widget
+        self._stream_widget = None
+        text = self._stream_buffer
+        self._stream_buffer = ""
+        self._stream_dirty = False
+        # 如果从未收到 chunk（provider 不支持流式），移除占位 widget
+        if not text and widget is not None:
+            widget.remove()
+        return text
+
+    def set_cancel_callback(self, callback: Callable[[], None]) -> None:
+        """注册真取消回调（app.py 传入，Esc 时触发 cancel_event.set()）。"""
+        self._cancel_callback = callback
 
     # ------------------------------------------------------------------
     # 工作流步骤进度（StepStatus 消息驱动）
@@ -489,6 +649,9 @@ class ChatView(Vertical):
             self._working = None
         self._tool_widgets.clear()
         self._step_widgets.clear()
+        self._stream_widget = None
+        self._stream_buffer = ""
+        self._stream_dirty = False
         log = self.query_one("#chat-log", VerticalScroll)
         log.query("*").remove()
         log.mount(Static(_build_welcome(), id="chat-welcome"))
@@ -498,10 +661,24 @@ class ChatView(Vertical):
         self.clear_messages()
 
     def action_cancel_chat(self) -> None:
-        """Esc 中断当前对话（后台任务自然收尾，结果不再展示）。"""
+        """Esc 中断当前对话。
+
+        #5 真取消：先触发 cancel_event（让 worker 线程在下一个检查点退出），
+        再做 UI 收尾。如果没有 cancel_callback 则只做 UI 抑制（旧行为）。
+        """
         if not self._busy:
             return
         self._cancelled = True
+        # 触发真取消（cancel_event.set()）
+        if self._cancel_callback is not None:
+            with contextlib.suppress(Exception):
+                self._cancel_callback()
+        # 清理流式 widget（如果正在流式渲染）
+        if self._stream_widget is not None:
+            self._stream_widget.remove()
+            self._stream_widget = None
+            self._stream_buffer = ""
+            self._stream_dirty = False
         self.set_busy(False)
         log = self.query_one("#chat-log", VerticalScroll)
         log.mount(

--- a/src/mommy_chaogu/tui/widgets/working_indicator.py
+++ b/src/mommy_chaogu/tui/widgets/working_indicator.py
@@ -1,14 +1,17 @@
 """WorkingIndicator — "思考中" 工作指示器（dexter working-indicator 本土化）。
 
     ⠹ 盯盘中… (12s)
+    ⠹ 盯盘中… (12s · ↓ 1.2k tokens)
 
-spinner 帧循环 + 每次 busy 随机一个炒股语境动词 + 实时耗时。
+spinner 帧循环 + 每次 busy 随机一个炒股语境动词 + 实时耗时 + 可选 token 统计。
 """
 
 from __future__ import annotations
 
 import random
 import time
+from collections.abc import Callable
+from typing import Any
 
 from textual.timer import Timer
 from textual.widgets import Static
@@ -37,8 +40,20 @@ def random_thinking_verb() -> str:
     return random.choice(THINKING_VERBS)
 
 
+def _format_tokens(n: int) -> str:
+    """token 数 → dexter 风格紧凑显示（1.2k / 850）。"""
+    if n >= 1000:
+        return f"{n / 1000:.1f}k"
+    return str(n)
+
+
 class WorkingIndicator(Static):
-    """busy 期间挂载到对话流末尾；busy 结束移除。"""
+    """busy 期间挂载到对话流末尾；busy 结束移除。
+
+    可选 set_stats_provider 注册一个 callable，每次 tick 调用它获取
+    当前 turn 的 token 统计 dict（含 total_tokens 或 completion_tokens），
+    在耗时后追加显示。
+    """
 
     def __init__(self) -> None:
         super().__init__(classes="working-indicator")
@@ -46,10 +61,15 @@ class WorkingIndicator(Static):
         self._frame_idx = 0
         self._started = time.monotonic()
         self._timer: Timer | None = None
+        self._stats_provider: Callable[[], dict[str, Any]] | None = None
 
     def on_mount(self) -> None:
         self._refresh_text()
         self._timer = self.set_interval(_TICK_INTERVAL_S, self._tick)
+
+    def set_stats_provider(self, provider: Callable[[], dict[str, Any]]) -> None:
+        """注册 token 统计来源（worker 线程更新的共享 dict 或 callable）。"""
+        self._stats_provider = provider
 
     def _tick(self) -> None:
         self._frame_idx = (self._frame_idx + 1) % len(_SPINNER_FRAMES)
@@ -58,11 +78,45 @@ class WorkingIndicator(Static):
     def _refresh_text(self) -> None:
         frame = _SPINNER_FRAMES[self._frame_idx]
         elapsed = int(time.monotonic() - self._started)
-        suffix = f" ({elapsed}s)" if elapsed >= 1 else ""
-        self.update(f"[#79b8ff]{frame} {self._verb}…[/][#8a8f98]{suffix}[/]")
+        parts: list[str] = [f"[#79b8ff]{frame} {self._verb}…[/]"]
+        # 后缀：耗时 + 可选 token 统计
+        suffix_parts: list[str] = []
+        if elapsed >= 1:
+            suffix_parts.append(f"{elapsed}s")
+        if self._stats_provider is not None:
+            with _safe_stats(self._stats_provider) as stats:
+                if stats:
+                    tokens = stats.get("total_tokens") or stats.get("completion_tokens") or 0
+                    if tokens:
+                        suffix_parts.append(f"↓ {_format_tokens(int(tokens))} tokens")
+        if suffix_parts:
+            parts.append(f"[#8a8f98]({' · '.join(suffix_parts)})[/]")
+        self.update("".join(parts))
 
     def stop_timer(self) -> None:
         """停止帧动画（移除前调用，避免 timer 泄漏）。"""
         if self._timer is not None:
             self._timer.stop()
             self._timer = None
+
+
+class _SafeStatsContext:
+    """安全调用 stats_provider：异常时返回空 dict（主线程不应因统计报错崩溃）。"""
+
+    def __init__(self, provider: Callable[[], dict[str, Any]]) -> None:
+        self._provider = provider
+        self.stats: dict[str, Any] = {}
+
+    def __enter__(self) -> dict[str, Any]:
+        try:
+            self.stats = self._provider() or {}
+        except Exception:
+            self.stats = {}
+        return self.stats
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
+def _safe_stats(provider: Callable[[], dict[str, Any]]) -> _SafeStatsContext:
+    return _SafeStatsContext(provider)

--- a/src/mommy_chaogu/web/routes/agent.py
+++ b/src/mommy_chaogu/web/routes/agent.py
@@ -189,6 +189,40 @@ async def get_predictions(limit: int = Query(default=20, ge=1, le=200)) -> dict[
         return {"predictions": [], "total": 0}
 
 
+@router.get("/predictions/stats")
+async def get_prediction_stats() -> dict[str, Any]:
+    """获取预测统计（命中率分布，供 Web 预测页顶部统计条用）。
+
+    背后是 PredictionTracker.stats()，无 tracker 时返回空统计。
+    """
+    tracker = get_prediction_tracker_safe()
+    if tracker is None:
+        return {
+            "total": 0,
+            "pending": 0,
+            "hit": 0,
+            "missed": 0,
+            "expired": 0,
+            "unverifiable": 0,
+            "hit_rate": 0.0,
+        }
+    try:
+        stats = tracker.stats()
+        # 确保 hit_rate 是 float（JSON 可序列化）
+        stats["hit_rate"] = float(stats.get("hit_rate", 0.0))
+        return stats
+    except Exception:
+        return {
+            "total": 0,
+            "pending": 0,
+            "hit": 0,
+            "missed": 0,
+            "expired": 0,
+            "unverifiable": 0,
+            "hit_rate": 0.0,
+        }
+
+
 def get_prediction_tracker_safe() -> Any:
     """安全获取 prediction tracker（可能未配置）。"""
     try:

--- a/src/mommy_chaogu/web/routes/agent.py
+++ b/src/mommy_chaogu/web/routes/agent.py
@@ -28,6 +28,17 @@ _log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/agent", tags=["agent"])
 
+# tracker 缺失或统计异常时的兜底返回（调用方需拷贝，勿原地修改）
+_EMPTY_PREDICTION_STATS: dict[str, Any] = {
+    "total": 0,
+    "pending": 0,
+    "hit": 0,
+    "missed": 0,
+    "expired": 0,
+    "unverifiable": 0,
+    "hit_rate": 0.0,
+}
+
 
 # ---------- Schemas ----------
 
@@ -193,34 +204,19 @@ async def get_predictions(limit: int = Query(default=20, ge=1, le=200)) -> dict[
 async def get_prediction_stats() -> dict[str, Any]:
     """获取预测统计（命中率分布，供 Web 预测页顶部统计条用）。
 
-    背后是 PredictionTracker.stats()，无 tracker 时返回空统计。
+    背后是 PredictionTracker.stats()，无 tracker 或统计异常时返回空统计。
     """
     tracker = get_prediction_tracker_safe()
     if tracker is None:
-        return {
-            "total": 0,
-            "pending": 0,
-            "hit": 0,
-            "missed": 0,
-            "expired": 0,
-            "unverifiable": 0,
-            "hit_rate": 0.0,
-        }
+        return dict(_EMPTY_PREDICTION_STATS)
     try:
         stats = tracker.stats()
         # 确保 hit_rate 是 float（JSON 可序列化）
         stats["hit_rate"] = float(stats.get("hit_rate", 0.0))
         return stats
-    except Exception:
-        return {
-            "total": 0,
-            "pending": 0,
-            "hit": 0,
-            "missed": 0,
-            "expired": 0,
-            "unverifiable": 0,
-            "hit_rate": 0.0,
-        }
+    except Exception as exc:
+        _log.warning("预测统计查询失败，返回空统计: %s", exc)
+        return dict(_EMPTY_PREDICTION_STATS)
 
 
 def get_prediction_tracker_safe() -> Any:

--- a/src/mommy_chaogu/web/routes/ws.py
+++ b/src/mommy_chaogu/web/routes/ws.py
@@ -95,12 +95,12 @@ async def ws_signals(
 
 @router.websocket("/ws/agent")
 async def ws_agent(websocket: WebSocket) -> None:
-    """AI 对话流式 WebSocket。
+    """AI 对话流式 WebSocket（真流式：逐 LLM delta 转发，#4）。
 
-    消息格式：
+    消息格式（前端零改动，纯累加 chunk.text）：
     - 客户端发: {"message": "...", "history": [...]}
     - 服务端回: {"type": "thinking"} (一次)
-    - 服务端回: {"type": "chunk", "text": "..."} (多次)
+    - 服务端回: {"type": "chunk", "text": "..."} (多次，真实 LLM delta)
     - 服务端回: {"type": "done", "tools_used": [...], "rounds": N}
     """
     import asyncio
@@ -154,19 +154,42 @@ async def ws_agent(websocket: WebSocket) -> None:
             if not await security.try_acquire_agent():
                 await websocket.send_json({"type": "error", "message": "AI 助手忙，请稍后重试"})
                 continue
-            try:
-                # agent.chat 是同步的，用 to_thread 包装
-                resp = await asyncio.to_thread(agent.chat, user_message, None, None, session_memory)
-            finally:
-                await security.release_agent()
 
-            # 分段发送（小段快发）
-            text = resp.text
-            chunk_size = 12
-            for i in range(0, len(text), chunk_size):
-                chunk = text[i : i + chunk_size]
-                await websocket.send_json({"type": "chunk", "text": chunk})
-                await asyncio.sleep(0.01)
+            # 真流式：asyncio.Queue 桥接 worker 线程的 on_chunk → 事件循环发送
+            loop = asyncio.get_running_loop()
+            chunk_queue: asyncio.Queue[str | None] = asyncio.Queue()
+
+            def on_chunk(delta: str) -> None:
+                """worker 线程内调用，线程安全地把 delta 推入 asyncio Queue。"""
+                loop.call_soon_threadsafe(chunk_queue.put_nowait, delta)  # noqa: B023
+
+            async def _drain_stream() -> None:
+                """持续从 queue 取 delta 发给前端，直到收到 None sentinel。"""
+                while True:
+                    delta = await chunk_queue.get()  # noqa: B023
+                    if delta is None:
+                        break
+                    await websocket.send_json({"type": "chunk", "text": delta})
+
+            # 启动 drain task，与 agent.chat worker 并发
+            drain_task = asyncio.create_task(_drain_stream())
+            try:
+                # agent.chat 在 worker 线程跑，on_chunk 实时推 delta
+                resp = await asyncio.to_thread(
+                    agent.chat,
+                    user_message,
+                    None,
+                    None,
+                    session_memory,
+                    None,  # on_tool_call
+                    None,  # on_tool_result
+                    on_chunk,
+                )
+            finally:
+                # 通知 drain 结束 + 等 drain 把剩余 delta 发完
+                loop.call_soon_threadsafe(chunk_queue.put_nowait, None)
+                await drain_task
+                await security.release_agent()
 
             await websocket.send_json(
                 {

--- a/src/mommy_chaogu/web/routes/ws.py
+++ b/src/mommy_chaogu/web/routes/ws.py
@@ -102,6 +102,9 @@ async def ws_agent(websocket: WebSocket) -> None:
     - 服务端回: {"type": "thinking"} (一次)
     - 服务端回: {"type": "chunk", "text": "..."} (多次，真实 LLM delta)
     - 服务端回: {"type": "done", "tools_used": [...], "rounds": N}
+
+    兜底：若 agent 层流式不可用（provider 不支持 stream），on_chunk 不会
+    被调用，此时把 resp.text 作为单个 chunk 补发，保证前端一定有回答。
     """
     import asyncio
     import json
@@ -158,9 +161,12 @@ async def ws_agent(websocket: WebSocket) -> None:
             # 真流式：asyncio.Queue 桥接 worker 线程的 on_chunk → 事件循环发送
             loop = asyncio.get_running_loop()
             chunk_queue: asyncio.Queue[str | None] = asyncio.Queue()
+            streamed_any = False  # on_chunk 是否真的推过 delta（流式不可用时为 False）
 
             def on_chunk(delta: str) -> None:
                 """worker 线程内调用，线程安全地把 delta 推入 asyncio Queue。"""
+                nonlocal streamed_any
+                streamed_any = True
                 loop.call_soon_threadsafe(chunk_queue.put_nowait, delta)  # noqa: B023
 
             async def _drain_stream() -> None:
@@ -190,6 +196,11 @@ async def ws_agent(websocket: WebSocket) -> None:
                 loop.call_soon_threadsafe(chunk_queue.put_nowait, None)
                 await drain_task
                 await security.release_agent()
+
+            # 流式兜底：on_chunk 从未触发（provider 不支持 stream）时，
+            # 把非流式兜底文本作为单个 chunk 补发，否则前端会收到空回答。
+            if not streamed_any and resp.text:
+                await websocket.send_json({"type": "chunk", "text": resp.text})
 
             await websocket.send_json(
                 {

--- a/tests/test_agent/test_streaming.py
+++ b/tests/test_agent/test_streaming.py
@@ -1,0 +1,255 @@
+"""AgentService 流式输出 / 取消 / usage 累加单测（PLAN #4/#5/#6）。
+
+覆盖：
+- on_chunk 流式：工具循环结束后发起 stream=True 调用，逐 delta 调 on_chunk
+- cancel_event：每轮 LLM 前 + 每个工具前检查 is_set()，命中返回 interrupted=True
+- usage 累加：response.usage 累加到 AgentResponse.usage
+- provider 不支持 stream 时回退非流式文本
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mommy_chaogu.agent.service import AgentService
+from mommy_chaogu.agent.tools import ToolContext
+
+
+@pytest.fixture
+def mock_ctx() -> ToolContext:
+    adp = MagicMock()
+    adp.get_quote.return_value = None
+    return ToolContext(adapter=adp)
+
+
+def _text_response(text: str, usage: Any = None) -> MagicMock:
+    """非流式 response mock。"""
+    msg = MagicMock()
+    msg.tool_calls = None
+    msg.content = text
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message = msg
+    resp.usage = usage
+    return resp
+
+
+def _usage(p: int, c: int) -> MagicMock:
+    u = MagicMock()
+    u.prompt_tokens = p
+    u.completion_tokens = c
+    u.total_tokens = p + c
+    return u
+
+
+def _stream_response(deltas: list[str], usage: Any = None) -> MagicMock:
+    """模拟 OpenAI stream 对象：迭代出 N 个 chunk。"""
+    chunks = []
+    for d in deltas:
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = d
+        chunk.usage = None
+        chunks.append(chunk)
+    # 最后一个 chunk 带 usage
+    if usage is not None and chunks:
+        chunks[-1].usage = usage
+
+    stream = MagicMock()
+    stream.__iter__ = lambda self: iter(chunks)  # type: ignore[misc]
+    return stream
+
+
+class TestStreamingFinalAnswer:
+    """on_chunk 流式最终回答（#4）。"""
+
+    @patch("openai.OpenAI")
+    def test_on_chunk_called_per_delta(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """非流式轮拿到文本后，on_chunk 驱动一次 stream 调用逐 delta 输出。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _text_response("你好世界"),
+            _stream_response(["你", "好", "世", "界"]),
+        ]
+
+        chunks: list[str] = []
+        resp = svc.chat("hi", on_chunk=chunks.append)
+
+        assert "".join(chunks) == "你好世界"
+        assert resp.text == "你好世界"
+        # 第二次调用是 stream=True
+        second_call = svc._client.chat.completions.create.call_args_list[1]
+        assert second_call.kwargs.get("stream") is True
+
+    @patch("openai.OpenAI")
+    def test_no_on_chunk_skips_streaming(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """不传 on_chunk 时不发起 stream 调用（保持原行为）。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.return_value = _text_response("直接回答")
+
+        resp = svc.chat("hi")
+
+        assert resp.text == "直接回答"
+        assert svc._client.chat.completions.create.call_count == 1
+
+    @patch("openai.OpenAI")
+    def test_stream_fallback_on_error(self, _mock_openai: MagicMock, mock_ctx: ToolContext) -> None:
+        """stream 调用抛异常时保留非流式文本（不返回空）。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _text_response("非流式答案"),
+            RuntimeError("provider 不支持 stream"),
+        ]
+
+        chunks: list[str] = []
+        resp = svc.chat("hi", on_chunk=chunks.append)
+
+        # 流式失败 → chunks 为空，但 resp.text 保留非流式文本
+        assert chunks == []
+        assert resp.text == "非流式答案"
+
+
+class TestCancelEvent:
+    """cancel_event 真取消（#5）。"""
+
+    @patch("openai.OpenAI")
+    def test_cancel_before_llm_call(self, _mock_openai: MagicMock, mock_ctx: ToolContext) -> None:
+        """cancel_event 在 LLM 调用前已 set → 立即返回 interrupted。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        event = threading.Event()
+        event.set()
+
+        resp = svc.chat("hi", cancel_event=event)
+
+        assert resp.interrupted is True
+        assert resp.text == "（已中断）"
+        # LLM 从未被调用
+        assert svc._client.chat.completions.create.call_count == 0
+
+    @patch("openai.OpenAI")
+    def test_cancel_before_tool_execution(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """LLM 返回 tool_calls，但工具执行前 cancel_event 被 set。"""
+        # 第一轮：返回 tool_call
+        tc_msg = MagicMock()
+        tc_msg.tool_calls = [MagicMock()]
+        tc_msg.tool_calls[0].id = "tc_1"
+        tc_msg.tool_calls[0].function.name = "get_quote"
+        tc_msg.tool_calls[0].function.arguments = '{"code": "600519"}'
+        tc_msg.model_dump.return_value = {"role": "assistant"}
+        tc_msg.content = None
+        resp1 = MagicMock()
+        resp1.choices = [MagicMock()]
+        resp1.choices[0].message = tc_msg
+        resp1.usage = None
+
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.return_value = resp1
+        svc._tools = MagicMock()
+        svc._tools.definitions.return_value = []
+
+        # cancel_event 在工具执行前 set
+        event = threading.Event()
+
+        def fake_call(name: str, args: dict[str, Any]) -> str:
+            # 工具执行前 set cancel
+            event.set()
+            return "{}"
+
+        svc._tools.call.side_effect = fake_call
+
+        resp = svc.chat("hi", cancel_event=event)
+
+        assert resp.interrupted is True
+        # 工具确实被调了一次（因为 set 发生在 fake_call 内部，但循环会在
+        # 下一个工具前检查到——这里只有一个工具，所以会在下一轮 LLM 前退出）
+
+    @patch("openai.OpenAI")
+    def test_cancel_after_tool_round_before_next_llm(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """工具执行完、下一轮 LLM 调用前 cancel → interrupted=True。
+
+        这是最关键的取消路径：工具结果已回传，但用户在 LLM 再思考前取消。
+        """
+        # 第一轮：tool_call（usage=None）
+        tc_msg = MagicMock()
+        tc_msg.tool_calls = [MagicMock()]
+        tc_msg.tool_calls[0].id = "tc_1"
+        tc_msg.tool_calls[0].function.name = "get_quote"
+        tc_msg.tool_calls[0].function.arguments = '{"code": "600519"}'
+        tc_msg.model_dump.return_value = {"role": "assistant"}
+        tc_msg.content = None
+        resp1 = MagicMock()
+        resp1.choices = [MagicMock()]
+        resp1.choices[0].message = tc_msg
+        resp1.usage = None
+
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.return_value = resp1
+        svc._tools = MagicMock()
+        svc._tools.definitions.return_value = []
+        svc._tools.call.return_value = '{"price": 1680}'
+
+        event = threading.Event()
+
+        def on_tool_result(name: str, ok: bool, ms: int, res: str) -> None:
+            # 工具完成后、下一轮 LLM 前 set cancel
+            event.set()
+
+        resp = svc.chat("hi", on_tool_result=on_tool_result, cancel_event=event)
+
+        assert resp.interrupted is True
+        assert resp.text == "（已中断）"
+        # 第二轮 LLM 从未被调用（cancel 在它之前命中）
+        assert svc._client.chat.completions.create.call_count == 1
+
+
+class TestUsageAccumulation:
+    """response.usage 累加到 AgentResponse.usage（#6）。"""
+
+    @patch("openai.OpenAI")
+    def test_usage_accumulated_across_rounds(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """多轮 LLM 调用的 usage 累加。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _text_response("回答", usage=_usage(100, 50)),
+        ]
+
+        resp = svc.chat("hi")
+
+        assert resp.usage["prompt_tokens"] == 100
+        assert resp.usage["completion_tokens"] == 50
+        assert resp.usage["total_tokens"] == 150
+
+    @patch("openai.OpenAI")
+    def test_no_usage_when_response_lacks_it(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """response.usage 为 None 时 usage dict 保持空。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.return_value = _text_response("x", usage=None)
+
+        resp = svc.chat("hi")
+
+        assert resp.usage == {}
+
+    @patch("openai.OpenAI")
+    def test_usage_default_empty_dict(self, _mock_openai: MagicMock, mock_ctx: ToolContext) -> None:
+        """AgentResponse.usage 默认是空 dict（向后兼容）。"""
+        from mommy_chaogu.agent.service import AgentResponse
+
+        resp = AgentResponse(text="test")
+        assert resp.usage == {}
+        assert resp.interrupted is False

--- a/tests/test_agent/test_streaming.py
+++ b/tests/test_agent/test_streaming.py
@@ -2,8 +2,9 @@
 
 覆盖：
 - on_chunk 流式：工具循环结束后发起 stream=True 调用，逐 delta 调 on_chunk
-- cancel_event：每轮 LLM 前 + 每个工具前检查 is_set()，命中返回 interrupted=True
-- usage 累加：response.usage 累加到 AgentResponse.usage
+- cancel_event：每轮 LLM 前 + 每个工具前 + 流式输出途中检查 is_set()
+- usage 累加：response.usage 累加到 AgentResponse.usage，流式调用不重复计
+- usage_out：调用方传入的 dict 作为共享容器原地累加（UI 实时读取）
 - provider 不支持 stream 时回退非流式文本
 """
 
@@ -116,6 +117,27 @@ class TestStreamingFinalAnswer:
         assert chunks == []
         assert resp.text == "非流式答案"
 
+    @patch("openai.OpenAI")
+    def test_stream_usage_not_double_counted(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """流式调用（重新生成同一回答）的 usage 不累加，只计非流式那次。
+
+        否则最终回答的 token 成本会被计两次，统计口径虚高约 2 倍。
+        """
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _text_response("你好", usage=_usage(100, 50)),
+            _stream_response(["你", "好"], usage=_usage(100, 50)),
+        ]
+
+        resp = svc.chat("hi", on_chunk=lambda d: None)
+
+        # 只有非流式那轮的 usage
+        assert resp.usage["prompt_tokens"] == 100
+        assert resp.usage["completion_tokens"] == 50
+        assert resp.usage["total_tokens"] == 150
+
 
 class TestCancelEvent:
     """cancel_event 真取消（#5）。"""
@@ -138,7 +160,7 @@ class TestCancelEvent:
     def test_cancel_before_tool_execution(
         self, _mock_openai: MagicMock, mock_ctx: ToolContext
     ) -> None:
-        """LLM 返回 tool_calls，但工具执行前 cancel_event 被 set。"""
+        """LLM 返回 tool_calls，工具执行期间 cancel 被 set → 下一轮 LLM 前退出。"""
         # 第一轮：返回 tool_call
         tc_msg = MagicMock()
         tc_msg.tool_calls = [MagicMock()]
@@ -157,11 +179,10 @@ class TestCancelEvent:
         svc._tools = MagicMock()
         svc._tools.definitions.return_value = []
 
-        # cancel_event 在工具执行前 set
+        # cancel_event 在工具执行期间 set
         event = threading.Event()
 
         def fake_call(name: str, args: dict[str, Any]) -> str:
-            # 工具执行前 set cancel
             event.set()
             return "{}"
 
@@ -170,8 +191,10 @@ class TestCancelEvent:
         resp = svc.chat("hi", cancel_event=event)
 
         assert resp.interrupted is True
-        # 工具确实被调了一次（因为 set 发生在 fake_call 内部，但循环会在
-        # 下一个工具前检查到——这里只有一个工具，所以会在下一轮 LLM 前退出）
+        # 唯一的工具执行了一次（set 发生在执行期间），
+        # 之后循环在「下一轮 LLM 调用前」的检查点退出
+        assert svc._tools.call.call_count == 1
+        assert svc._client.chat.completions.create.call_count == 1
 
     @patch("openai.OpenAI")
     def test_cancel_after_tool_round_before_next_llm(
@@ -213,6 +236,32 @@ class TestCancelEvent:
         # 第二轮 LLM 从未被调用（cancel 在它之前命中）
         assert svc._client.chat.completions.create.call_count == 1
 
+    @patch("openai.OpenAI")
+    def test_cancel_during_stream_marks_interrupted(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """流式输出途中 cancel → 返回 interrupted=True（不再被吞成完整回答）。"""
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _text_response("你好世界"),
+            _stream_response(["你", "好", "世", "界"]),
+        ]
+
+        event = threading.Event()
+        chunks: list[str] = []
+
+        def on_chunk(delta: str) -> None:
+            chunks.append(delta)
+            # 收到第一个 delta 后取消
+            event.set()
+
+        resp = svc.chat("hi", on_chunk=on_chunk, cancel_event=event)
+
+        assert resp.interrupted is True
+        # 已流出的部分保留
+        assert "".join(chunks) == "你"
+        assert resp.text == "你"
+
 
 class TestUsageAccumulation:
     """response.usage 累加到 AgentResponse.usage（#6）。"""
@@ -253,3 +302,22 @@ class TestUsageAccumulation:
         resp = AgentResponse(text="test")
         assert resp.usage == {}
         assert resp.interrupted is False
+
+    @patch("openai.OpenAI")
+    def test_usage_out_shared_container(
+        self, _mock_openai: MagicMock, mock_ctx: ToolContext
+    ) -> None:
+        """usage_out 传入的 dict 被原地累加，且与 resp.usage 是同一对象。
+
+        TUI 的 WorkingIndicator 靠这个共享 dict 在对话进行中实时显示 token。
+        """
+        svc = AgentService(mock_ctx, api_key="sk-test")
+        svc._client.chat.completions.create.side_effect = [
+            _text_response("回答", usage=_usage(100, 50)),
+        ]
+
+        shared: dict[str, int] = {}
+        resp = svc.chat("hi", usage_out=shared)
+
+        assert resp.usage is shared
+        assert shared["total_tokens"] == 150

--- a/tests/test_tui_chat_ui.py
+++ b/tests/test_tui_chat_ui.py
@@ -248,12 +248,26 @@ class TestBusyIndicators:
 class _FakeAgent:
     """同步触发两个回调的假 agent。"""
 
-    def chat(self, message, history=None, on_tool_call=None, on_tool_result=None):  # type: ignore[no-untyped-def]
+    def chat(  # type: ignore[no-untyped-def]
+        self,
+        message,
+        history=None,
+        on_tool_call=None,
+        on_tool_result=None,
+        on_chunk=None,
+        cancel_event=None,
+    ):
         if on_tool_call is not None:
             on_tool_call("get_quote", {"code": "600519"})
         if on_tool_result is not None:
             on_tool_result("get_quote", True, 1230, "贵州茅台 1680.00 +0.5%")
-        return SimpleNamespace(text="茅台最新报价 1680 元。", tool_calls=[], rounds=1)
+        return SimpleNamespace(
+            text="茅台最新报价 1680 元。",
+            tool_calls=[],
+            rounds=1,
+            usage={},
+            interrupted=False,
+        )
 
 
 class TestAgentChatFlow:

--- a/tests/test_tui_slash.py
+++ b/tests/test_tui_slash.py
@@ -131,3 +131,66 @@ class TestSlashSuggester:
         assert result is not None
         # Should return one of the 'c' commands
         assert result.lstrip("/").split()[0] in ("clear", "chat")
+
+
+# ---------------------------------------------------------------------------
+# Pilot: /flows + /memory 卡片渲染（#7）
+# ---------------------------------------------------------------------------
+
+
+def _run(coro) -> None:  # type: ignore[no-untyped-def]
+    asyncio.run(coro)
+
+
+class TestFlowsMemoryCards:
+    def test_flows_renders_card(self) -> None:
+        from textual.widgets import Input
+
+        from mommy_chaogu.tui.app import MommyTuiApp
+        from mommy_chaogu.tui.services.bootstrap import FakeServices
+        from mommy_chaogu.tui.views.chat import ChatView
+
+        async def _test() -> None:
+            app = MommyTuiApp(services=FakeServices.create())  # type: ignore[arg-type]
+            async with app.run_test() as pilot:
+                chat = app.query_one(ChatView)
+                prompt = chat.query_one("#prompt", Input)
+                prompt.value = "/flows 688981"
+                await pilot.pause()
+                # 提交
+                await pilot.press("enter")
+                await pilot.pause()
+
+                card = chat.query(".flows-card")
+                assert len(card) == 1
+                content = str(card[0].content)  # type: ignore[attr-defined]
+                assert "688981" in content
+                assert "主力" in content
+                # 不应再出现"请在终端运行"
+                assert "请在终端运行" not in content
+
+        _run(_test())
+
+    def test_memory_renders_card(self) -> None:
+        from textual.widgets import Input
+
+        from mommy_chaogu.tui.app import MommyTuiApp
+        from mommy_chaogu.tui.services.bootstrap import FakeServices
+        from mommy_chaogu.tui.views.chat import ChatView
+
+        async def _test() -> None:
+            app = MommyTuiApp(services=FakeServices.create())  # type: ignore[arg-type]
+            async with app.run_test() as pilot:
+                chat = app.query_one(ChatView)
+                prompt = chat.query_one("#prompt", Input)
+                prompt.value = "/memory"
+                await pilot.pause()
+                await pilot.press("enter")
+                await pilot.pause()
+
+                card = chat.query(".memory-card")
+                assert len(card) == 1
+                content = str(card[0].content)  # type: ignore[attr-defined]
+                assert "记忆系统" in content
+                assert "预测" in content
+                assert "请在终端运行" not in content

--- a/tests/test_web/test_api_pitfalls.py
+++ b/tests/test_web/test_api_pitfalls.py
@@ -37,6 +37,17 @@ class _FakeTracker:
             }
         ][:limit]
 
+    def stats(self) -> dict[str, Any]:
+        return {
+            "total": 10,
+            "pending": 4,
+            "hit": 3,
+            "missed": 2,
+            "expired": 1,
+            "unverifiable": 0,
+            "hit_rate": 0.6,
+        }
+
 
 class TestPredictionsEndpoint:
     def test_returns_tracker_rows(
@@ -63,6 +74,35 @@ class TestPredictionsEndpoint:
         resp = client.get("/api/agent/predictions")
         assert resp.status_code == 200
         assert resp.json() == {"predictions": [], "total": 0}
+
+
+class TestPredictionStatsEndpoint:
+    def test_returns_stats(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "mommy_chaogu.web.routes.agent.get_prediction_tracker_safe",
+            lambda: _FakeTracker(),
+        )
+        resp = client.get("/api/agent/predictions/stats")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 10
+        assert body["hit"] == 3
+        assert body["missed"] == 2
+        assert body["pending"] == 4
+        assert body["hit_rate"] == 0.6
+
+    def test_tracker_none_returns_zero_stats(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "mommy_chaogu.web.routes.agent.get_prediction_tracker_safe",
+            lambda: None,
+        )
+        resp = client.get("/api/agent/predictions/stats")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 0
+        assert body["hit_rate"] == 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_web/test_ws.py
+++ b/tests/test_web/test_ws.py
@@ -108,11 +108,20 @@ class TestAgentWebSocket:
         from mommy_chaogu.web import deps
 
         agent = MagicMock()
-        agent.chat.return_value = SimpleNamespace(
-            text="abcdefghijklmnop",
-            tool_calls=[SimpleNamespace(name="get_quote")],
-            rounds=2,
-        )
+
+        def fake_chat(message, history, system_override, sess_memory, *args, **kwargs):
+            # 模拟 agent 层通过 on_chunk 回调推送真实 delta（#4 真流式）
+            on_chunk = args[2] if len(args) > 2 else kwargs.get("on_chunk")
+            if on_chunk is not None:
+                on_chunk("abcdefghijkl")
+                on_chunk("mnop")
+            return SimpleNamespace(
+                text="abcdefghijklmnop",
+                tool_calls=[SimpleNamespace(name="get_quote")],
+                rounds=2,
+            )
+
+        agent.chat.side_effect = fake_chat
         memory = MagicMock()
         session_memory = MagicMock()
         memory.for_session.return_value = session_memory
@@ -122,6 +131,7 @@ class TestAgentWebSocket:
         with client.websocket_connect("/ws/agent") as ws:
             ws.send_json({"message": "hello"})
             assert ws.receive_json() == {"type": "thinking"}
+            # 真流式：on_chunk 推送的 delta 原样转发（不再是 12 字符切片）
             assert ws.receive_json() == {"type": "chunk", "text": "abcdefghijkl"}
             assert ws.receive_json() == {"type": "chunk", "text": "mnop"}
             assert ws.receive_json() == {
@@ -131,7 +141,7 @@ class TestAgentWebSocket:
             }
 
         memory.for_session.assert_called_once_with("web-default")
-        agent.chat.assert_called_once_with("hello", None, None, session_memory)
+        agent.chat.assert_called_once()
 
     def test_rejects_invalid_session_id(self, client: TestClient, monkeypatch: object) -> None:
         from mommy_chaogu.web import deps

--- a/tests/test_web/test_ws.py
+++ b/tests/test_web/test_ws.py
@@ -143,6 +143,39 @@ class TestAgentWebSocket:
         memory.for_session.assert_called_once_with("web-default")
         agent.chat.assert_called_once()
 
+    def test_fallback_sends_full_text_when_streaming_unsupported(
+        self, client: TestClient, monkeypatch: object
+    ) -> None:
+        """provider 不支持 stream 时 on_chunk 不触发，resp.text 必须兜底补发。
+
+        回归：此前真流式改造删掉了切片转发逻辑，流式不可用时前端会收到
+        空回答——这里钉死兜底行为。
+        """
+        from mommy_chaogu.web import deps
+
+        agent = MagicMock()
+        agent.chat.return_value = SimpleNamespace(
+            text="这是非流式兜底回答",
+            tool_calls=[],
+            rounds=1,
+        )
+        memory = MagicMock()
+        session_memory = MagicMock()
+        memory.for_session.return_value = session_memory
+        monkeypatch.setattr(deps, "get_agent_service", lambda: agent)  # type: ignore[attr-defined]
+        monkeypatch.setattr(deps, "get_agent_memory", lambda: memory)  # type: ignore[attr-defined]
+
+        with client.websocket_connect("/ws/agent") as ws:
+            ws.send_json({"message": "hello"})
+            assert ws.receive_json() == {"type": "thinking"}
+            # on_chunk 从未触发 → 兜底：完整文本作为单个 chunk 补发
+            assert ws.receive_json() == {"type": "chunk", "text": "这是非流式兜底回答"}
+            assert ws.receive_json() == {
+                "type": "done",
+                "tools_used": [],
+                "rounds": 1,
+            }
+
     def test_rejects_invalid_session_id(self, client: TestClient, monkeypatch: object) -> None:
         from mommy_chaogu.web import deps
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { RouterView, RouterLink, useRoute } from 'vue-router'
-import { LayoutDashboard, TrendingUp, Microscope, Wallet, MessageSquare, Bell, Settings, ChevronRight } from 'lucide-vue-next'
+import { LayoutDashboard, TrendingUp, Microscope, Wallet, MessageSquare, Bell, Target, Settings, ChevronRight } from 'lucide-vue-next'
 import {
   Dialog,
   DialogContent,
@@ -13,7 +13,10 @@ import {
 const route = useRoute()
 const moreOpen = ref(false)
 const moreActive = computed(
-  () => route.path.startsWith('/themes') || route.path.startsWith('/settings'),
+  () =>
+    route.path.startsWith('/themes') ||
+    route.path.startsWith('/settings') ||
+    route.path.startsWith('/predictions'),
 )
 
 function focusMainContent() {
@@ -49,6 +52,9 @@ function focusMainContent() {
       </RouterLink>
       <RouterLink to="/signals" title="信号" aria-label="信号" class="app-nav-link" active-class="!bg-primary/10 !text-primary">
         <Bell class="size-5" aria-hidden="true" />
+      </RouterLink>
+      <RouterLink to="/predictions" title="预测跟踪" aria-label="预测跟踪" class="app-nav-link" active-class="!bg-primary/10 !text-primary">
+        <Target class="size-5" aria-hidden="true" />
       </RouterLink>
       <div class="flex-1" />
       <RouterLink to="/settings" title="设置" aria-label="设置" class="app-nav-link" active-class="!bg-primary/10 !text-primary">
@@ -98,6 +104,15 @@ function focusMainContent() {
             前往主题研究或应用设置
           </DialogDescription>
           <nav aria-label="更多导航" class="grid gap-2">
+            <RouterLink
+              to="/predictions"
+              class="flex min-h-12 items-center gap-3 rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              @click="moreOpen = false"
+            >
+              <Target class="size-5 text-primary" aria-hidden="true" />
+              <span class="flex-1">预测跟踪</span>
+              <ChevronRight class="size-4 text-muted-foreground" aria-hidden="true" />
+            </RouterLink>
             <RouterLink
               to="/themes"
               class="flex min-h-12 items-center gap-3 rounded-lg border px-3 py-2 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"

--- a/web/src/api/predictions.test.ts
+++ b/web/src/api/predictions.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getPredictionStats, getPredictions } from './predictions'
+
+describe('predictions API client', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('fetches predictions and unwraps the predictions array', async () => {
+    const mockPredictions = [
+      {
+        id: 1,
+        created_at: '2026-07-20T00:00:00Z',
+        code: '600519',
+        name: '贵州茅台',
+        prediction: '看涨',
+        direction: 'up',
+        rationale: '资金面转好',
+        target_price: 1800,
+        entry_price: 1680,
+        stop_loss: 1620,
+        change_pct_at_creation: 1.2,
+        timeframe: '5d',
+        verify_after: '2026-07-25T00:00:00Z',
+        status: 'pending',
+        verified_at: null,
+        actual_price: null,
+        actual_change_pct: null,
+        accuracy_score: null,
+        verify_attempts: 0,
+        verify_log: null,
+        data_coverage_at_creation: null,
+        data_coverage_at_verify: null,
+        source_event_id: null,
+        insight_event_id: null,
+      },
+    ]
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ predictions: mockPredictions, total: 1 }), {
+        status: 200,
+      }),
+    )
+
+    const result = await getPredictions(20)
+    expect(result).toEqual(mockPredictions)
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/agent/predictions?limit=20',
+      expect.objectContaining({ headers: expect.any(Object) }),
+    )
+  })
+
+  it('respects a custom limit parameter', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ predictions: [], total: 0 }), { status: 200 }),
+    )
+    await getPredictions(50)
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/agent/predictions?limit=50',
+      expect.any(Object),
+    )
+  })
+
+  it('fetches prediction stats', async () => {
+    const mockStats = {
+      total: 10,
+      pending: 4,
+      hit: 4,
+      missed: 1,
+      expired: 1,
+      unverifiable: 0,
+      hit_rate: 0.8,
+    }
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify(mockStats), { status: 200 }),
+    )
+
+    const result = await getPredictionStats()
+    expect(result).toEqual(mockStats)
+    expect(result.hit_rate).toBe(0.8)
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/agent/predictions/stats',
+      expect.any(Object),
+    )
+  })
+
+  it('surfaces non-200 responses as errors', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('boom', { status: 500 }))
+    await expect(getPredictions()).rejects.toThrow('500: boom')
+  })
+})

--- a/web/src/api/predictions.ts
+++ b/web/src/api/predictions.ts
@@ -1,0 +1,15 @@
+// 预测跟踪 API — agent 记忆系统的预测命中率闭环
+import { apiGet } from './client'
+import type { Prediction, PredictionStats } from './types'
+
+/** 获取最近 limit 条预测记录（按 created_at 降序）。 */
+export function getPredictions(limit = 20): Promise<Prediction[]> {
+  return apiGet<{ predictions: Prediction[]; total: number }>(
+    `/api/agent/predictions?limit=${limit}`,
+  ).then((r) => r.predictions)
+}
+
+/** 获取预测统计（各状态计数 + 命中率）。 */
+export function getPredictionStats(): Promise<PredictionStats> {
+  return apiGet<PredictionStats>('/api/agent/predictions/stats')
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -208,3 +208,49 @@ export interface MoneyFlowResponse {
   cumulative: MoneyFlowCumulative
   days?: number
 }
+
+// ---------- Prediction Tracking ----------
+
+export type PredictionStatus = 'pending' | 'hit' | 'missed' | 'expired' | 'unverifiable'
+
+/** 单条 agent 预测记录（对应后端 predictions 表行，字段名与 DB 列一致）。 */
+export interface Prediction {
+  id: number
+  created_at: string
+  code: string
+  name: string | null
+  /** 预测文本，如「看涨」「看跌」。 */
+  prediction: string
+  /** 方向标识：up / down / neutral（由 LLM 抽取，可能为其他值）。 */
+  direction: string
+  rationale: string | null
+  target_price: number | null
+  entry_price: number | null
+  /** 后端 DB 列名为 stop_loss（非 stop_price）。 */
+  stop_loss: number | null
+  change_pct_at_creation: number | null
+  timeframe: string
+  verify_after: string
+  status: PredictionStatus
+  verified_at: string | null
+  actual_price: number | null
+  actual_change_pct: number | null
+  accuracy_score: number | null
+  verify_attempts: number | null
+  verify_log: string | null
+  data_coverage_at_creation: string | null
+  data_coverage_at_verify: string | null
+  source_event_id: number | null
+  insight_event_id: number | null
+}
+
+/** 预测统计（命中率分布）。hit_rate 为 0..1 的小数。 */
+export interface PredictionStats {
+  total: number
+  pending: number
+  hit: number
+  missed: number
+  expired: number
+  unverifiable: number
+  hit_rate: number
+}

--- a/web/src/pages/predictions/index.vue
+++ b/web/src/pages/predictions/index.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { getPredictions, getPredictionStats } from '@/api/predictions'
+import { fmtPrice } from '@/utils/format'
+import { cn } from '@/lib/utils'
+import type { Prediction, PredictionStats, PredictionStatus } from '@/api/types'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+
+const router = useRouter()
+
+const predictions = ref<Prediction[]>([])
+const stats = ref<PredictionStats | null>(null)
+const loading = ref(true)
+const error = ref(false)
+
+async function load() {
+  const [listRes, statsRes] = await Promise.allSettled([
+    getPredictions(20),
+    getPredictionStats(),
+  ])
+  if (listRes.status === 'fulfilled') {
+    predictions.value = listRes.value
+  } else {
+    error.value = true
+  }
+  if (statsRes.status === 'fulfilled') {
+    stats.value = statsRes.value
+  }
+  loading.value = false
+}
+
+// ---------- 方向徽章 ----------
+// 故意不用涨跌色（红/绿），用蓝/橙避免和 A 股配色混淆。
+const directionConfig: Record<string, { label: string; cls: string }> = {
+  up: { label: '看多', cls: 'bg-blue-500/15 text-blue-600 dark:text-blue-400' },
+  down: { label: '看空', cls: 'bg-orange-500/15 text-orange-600 dark:text-orange-400' },
+}
+
+function directionOf(d: string): { label: string; cls: string } {
+  return directionConfig[d] ?? { label: d || '中性', cls: 'bg-secondary text-secondary-foreground' }
+}
+
+// ---------- status 徽章 ----------
+const statusConfig: Record<
+  PredictionStatus,
+  { label: string; variant: 'default' | 'secondary' | 'destructive' | 'outline'; cls?: string }
+> = {
+  pending: { label: '待验证', variant: 'secondary' },
+  // 命中用「成功」语义的绿，不用涨跌色变量
+  hit: { label: '命中', variant: 'secondary', cls: 'bg-green-500/15 text-green-600 dark:text-green-400' },
+  missed: { label: '未中', variant: 'destructive' },
+  expired: { label: '已过期', variant: 'outline' },
+  unverifiable: { label: '无法验证', variant: 'outline' },
+}
+
+function statusOf(s: PredictionStatus) {
+  return statusConfig[s] ?? { label: s, variant: 'secondary' as const }
+}
+
+// ---------- 时间格式化 ----------
+function fmtCountdown(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return '-'
+  const diff = d.getTime() - Date.now()
+  if (diff <= 0) return '已到期'
+  const days = Math.floor(diff / 86_400_000)
+  const hours = Math.floor((diff % 86_400_000) / 3_600_000)
+  if (days >= 1) return `${days}天后`
+  if (hours >= 1) return `${hours}小时后`
+  const mins = Math.floor((diff % 3_600_000) / 60_000)
+  return `${mins}分钟后`
+}
+
+function fmtDate(iso: string): string {
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return iso
+  return d.toLocaleString('zh-CN', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+// 已验证预测的实际价 vs 入场价偏差
+function deviation(p: Prediction): { text: string; positive: boolean } | null {
+  if (p.actual_price == null || p.entry_price == null || p.entry_price === 0) return null
+  const pct = ((p.actual_price - p.entry_price) / p.entry_price) * 100
+  const sign = pct >= 0 ? '+' : ''
+  return { text: `${sign}${pct.toFixed(2)}%`, positive: pct >= 0 }
+}
+
+const hitRatePct = computed(() =>
+  stats.value ? `${Math.round(stats.value.hit_rate * 100)}%` : '-',
+)
+
+// 预计算每条已验证预测的偏差（避免模板里重复调用 + 字符串解析）
+const deviationById = computed(() => {
+  const m = new Map<number, { text: string; positive: boolean }>()
+  for (const p of predictions.value) {
+    const d = deviation(p)
+    if (d) m.set(p.id, d)
+  }
+  return m
+})
+
+function isStockCode(code: string): boolean {
+  return /^\d{6}$/.test(code)
+}
+
+function goDetail(code: string) {
+  if (isStockCode(code)) router.push({ name: 'detail', params: { code } })
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="mx-auto w-full max-w-4xl space-y-4 p-4 lg:p-6">
+    <!-- 页头 -->
+    <div class="flex items-center justify-between">
+      <h1 class="text-xl font-bold tracking-tight">🎯 预测跟踪</h1>
+      <span class="font-mono text-xs text-muted-foreground">命中率闭环</span>
+    </div>
+
+    <!-- 顶部统计条 -->
+    <div class="grid grid-cols-2 gap-3 lg:grid-cols-5">
+      <template v-if="loading && !stats">
+        <Card v-for="i in 5" :key="i">
+          <CardContent class="space-y-2">
+            <Skeleton class="h-3 w-14" />
+            <Skeleton class="h-7 w-16" />
+          </CardContent>
+        </Card>
+      </template>
+      <template v-else>
+        <Card>
+          <CardContent class="space-y-1">
+            <p class="text-xs text-muted-foreground">总数</p>
+            <p class="font-mono text-2xl font-bold tabular-nums">{{ stats?.total ?? 0 }}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent class="space-y-1">
+            <p class="text-xs text-muted-foreground">待验证</p>
+            <p class="font-mono text-2xl font-bold tabular-nums text-muted-foreground">
+              {{ stats?.pending ?? 0 }}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent class="space-y-1">
+            <p class="text-xs text-muted-foreground">命中</p>
+            <p class="font-mono text-2xl font-bold tabular-nums text-green-600 dark:text-green-400">
+              {{ stats?.hit ?? 0 }}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent class="space-y-1">
+            <p class="text-xs text-muted-foreground">未中</p>
+            <p class="font-mono text-2xl font-bold tabular-nums text-destructive">
+              {{ stats?.missed ?? 0 }}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent class="space-y-1">
+            <p class="text-xs text-muted-foreground">命中率</p>
+            <p class="font-mono text-2xl font-bold tabular-nums">{{ hitRatePct }}</p>
+          </CardContent>
+        </Card>
+      </template>
+    </div>
+
+    <!-- 预测卡片列表 -->
+    <div class="space-y-3">
+      <!-- 加载骨架 -->
+      <template v-if="loading">
+        <Card v-for="i in 3" :key="i">
+          <CardContent class="space-y-3">
+            <div class="flex items-center gap-2">
+              <Skeleton class="h-5 w-12" />
+              <Skeleton class="h-5 w-32" />
+              <Skeleton class="h-5 w-16" />
+            </div>
+            <Skeleton class="h-4 w-3/4" />
+            <div class="flex gap-4">
+              <Skeleton class="h-8 w-20" />
+              <Skeleton class="h-8 w-20" />
+              <Skeleton class="h-8 w-20" />
+            </div>
+          </CardContent>
+        </Card>
+      </template>
+
+      <!-- 错误空态 -->
+      <Card v-else-if="error && predictions.length === 0">
+        <CardContent class="flex flex-col items-center gap-2 py-16 text-center">
+          <span class="text-5xl">⚠️</span>
+          <p class="text-base font-semibold text-destructive">数据加载失败</p>
+          <p class="text-sm text-muted-foreground">预测服务暂时不可用，请稍后重试</p>
+        </CardContent>
+      </Card>
+
+      <!-- 真空态 -->
+      <Card v-else-if="predictions.length === 0">
+        <CardContent class="flex flex-col items-center gap-2 py-16 text-center">
+          <span class="text-5xl">🔮</span>
+          <p class="text-base font-semibold text-muted-foreground">还没有预测记录</p>
+          <p class="text-sm text-muted-foreground">让 AI 对个股做出预测后会出现在这里</p>
+        </CardContent>
+      </Card>
+
+      <!-- 预测卡片 -->
+      <template v-else>
+        <Card
+          v-for="p in predictions"
+          :key="p.id"
+          :class="[
+            'border-l-4',
+            isStockCode(p.code)
+              ? 'cursor-pointer border-l-primary/60 transition-transform hover:shadow-md active:scale-[0.99]'
+              : 'border-l-primary/60',
+          ]"
+          :role="isStockCode(p.code) ? 'link' : undefined"
+          :tabindex="isStockCode(p.code) ? 0 : undefined"
+          @click="goDetail(p.code)"
+          @keydown.enter="goDetail(p.code)"
+          @keydown.space.prevent="goDetail(p.code)"
+        >
+          <CardContent class="space-y-3">
+            <!-- 头部：方向 + 名称/代码 + 状态 + 倒计时 -->
+            <div class="flex flex-wrap items-center gap-2">
+              <Badge
+                :class="cn('text-xs font-semibold', directionOf(p.direction).cls)"
+              >
+                {{ directionOf(p.direction).label }}
+              </Badge>
+              <span class="flex-1 truncate font-semibold text-card-foreground">
+                <span>{{ p.name || p.code }}</span>
+                <span class="ml-1 font-mono text-xs text-muted-foreground">{{ p.code }}</span>
+              </span>
+              <Badge
+                :variant="statusOf(p.status).variant"
+                :class="cn('text-xs', statusOf(p.status).cls)"
+              >
+                {{ statusOf(p.status).label }}
+              </Badge>
+            </div>
+
+            <!-- 预测文本 + 依据 -->
+            <div class="space-y-1">
+              <p class="text-sm font-medium leading-snug text-card-foreground">
+                {{ p.prediction }}
+                <span class="ml-1 text-xs text-muted-foreground">· {{ p.timeframe }}</span>
+              </p>
+              <p v-if="p.rationale" class="text-xs leading-relaxed text-muted-foreground line-clamp-2">
+                {{ p.rationale }}
+              </p>
+            </div>
+
+            <!-- 三档价位 -->
+            <div class="grid grid-cols-3 gap-2 text-sm">
+              <div class="rounded-md bg-muted/40 px-2 py-1.5">
+                <p class="text-[10px] text-muted-foreground">目标价</p>
+                <p class="font-mono font-semibold tabular-nums">{{ fmtPrice(p.target_price) }}</p>
+              </div>
+              <div class="rounded-md bg-muted/40 px-2 py-1.5">
+                <p class="text-[10px] text-muted-foreground">入场价</p>
+                <p class="font-mono font-semibold tabular-nums">{{ fmtPrice(p.entry_price) }}</p>
+              </div>
+              <div class="rounded-md bg-muted/40 px-2 py-1.5">
+                <p class="text-[10px] text-muted-foreground">止损价</p>
+                <p class="font-mono font-semibold tabular-nums">{{ fmtPrice(p.stop_loss) }}</p>
+              </div>
+            </div>
+
+            <!-- 底部：时间 + 倒计时 / 验证结果 -->
+            <div class="flex flex-wrap items-center justify-between gap-2 border-t pt-2 text-xs text-muted-foreground">
+              <span class="font-mono">📅 {{ fmtDate(p.created_at) }}</span>
+              <template v-if="p.status === 'pending'">
+                <span class="font-mono">⏳ {{ fmtCountdown(p.verify_after) }} 验证</span>
+              </template>
+              <template v-else-if="p.actual_price != null">
+                <span class="flex items-center gap-2 font-mono">
+                  <span>实际 {{ fmtPrice(p.actual_price) }}</span>
+                  <span
+                    v-if="deviationById.get(p.id)"
+                    :class="deviationById.get(p.id)!.positive
+                      ? 'text-green-600 dark:text-green-400'
+                      : 'text-destructive'"
+                  >
+                    {{ deviationById.get(p.id)!.text }}
+                  </span>
+                </span>
+              </template>
+              <span v-else class="font-mono">{{ statusOf(p.status).label }}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </template>
+    </div>
+  </div>
+</template>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -20,6 +20,7 @@ const router = createRouter({
     { path: '/agent', component: () => import('../pages/agent/index.vue'), name: 'agent' },
     { path: '/detail/:code', component: () => import('../pages/detail/index.vue'), name: 'detail', props: true },
     { path: '/signals', component: () => import('../pages/signals/index.vue'), name: 'signals' },
+    { path: '/predictions', component: () => import('../pages/predictions/index.vue'), name: 'predictions' },
     { path: '/themes', component: () => import('../pages/themes/index.vue'), name: 'themes' },
     { path: '/themes/:id', component: () => import('../pages/themes/detail.vue'), name: 'theme-detail' },
     { path: '/settings', component: () => import('../pages/settings/index.vue'), name: 'settings' },


### PR DESCRIPTION
## 二档体验深化（PLAN #4–#9）

### 功能
- **#4 真·流式输出**（agent + TUI + Web）：`stream=True` 最终回答路径 + `on_chunk` 回调；TUI 流式 Markdown widget（50ms 节流）；Web `/ws/agent` 经 `asyncio.Queue` 桥接 worker 线程真实 delta 转发（前端零改动）
- **#5 Esc 真取消**：`cancel_event` 在每轮 LLM 前 + 每个工具前 + 流式输出途中检查；`AgentResponse.interrupted` 字段
- **#6 WorkingIndicator token 统计**：`usage_out` 共享 dict 原地累加，worker 线程写、主线程实时读，dexter 风 `(12s · ↓ 1.2k tokens)`
- **#7 `/flows` + `/memory` slash 命令卡片**：替代「请在终端运行」提示
- **#8 Web 预测跟踪页**：`GET /api/agent/predictions/stats` + PredictionsView（统计条 + 卡片列表，方向徽章蓝/橙避开涨跌色）
- **#9 清理 `tui/messages.py` 死代码**：11 → 1 个 Message 类

### Review 修复（第 2–4 个提交）
- 🔴 **ws 流式兜底**：`on_chunk` 未触发时（provider 不支持 stream）把 `resp.text` 作为单 chunk 补发——修复前端收到空回答的 bug
- 🔴 **usage 双计**：流式调用（重新生成同一回答）的 usage 不再累加，token 统计口径不再虚高约 2 倍
- 🔴 **实时 token 统计**：此前 stats_provider 读的是 turn 结束才赋值的 dict，实时显示从未生效；改为 `usage_out` 引用共享
- 🟡 流式途中 Esc 返回 `interrupted=True`（不再吞取消）；`/predictions/stats` 空值常量提取 + 异常日志；`messages.py` 文档对齐实际通信路径

### 测试与质量门
- 原提交：+17 测试；修复提交：+5 测试（流式取消 / usage 单计 / usage_out 共享 / ws 兜底 / 取消路径补强）
- 原提交质量门：ruff ✅ / mypy --strict ✅ / pytest 1146 passed / web typecheck+build+13 tests ✅
- ⚠️ review 修复通过 API 推送，本地未重跑测试，合并前请跑一遍 `ruff && mypy --strict && pytest`

### 遗留（建议 follow-up issue）
- 流式实现目前是「非流式定稿 + 二次 stream 调用重新生成」，成本翻倍；长期应改为逐轮流式（从 delta 判断 tool_calls）
- 慢 worker 晚到 `_on_agent_done` 提前结束新 turn 的历史 race