### PR TITLE
fix(mcp): support MCP 2.0 connections

### DIFF
--- a/src/mommy_chaogu/agent/mcp_server.py
+++ b/src/mommy_chaogu/agent/mcp_server.py
@@ -30,7 +30,15 @@ from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool, ToolAnnotations
+from mcp.types import (
+    CallToolRequestParams,
+    CallToolResult,
+    ListToolsResult,
+    PaginatedRequestParams,
+    TextContent,
+    Tool,
+    ToolAnnotations,
+)
 
 from mommy_chaogu.agent.research_tools import (
     WRITE_TOOL_NAMES,
@@ -162,8 +170,6 @@ def create_mcp_server(
     selected_profile = normalize_mcp_profile(profile)
     registry = ToolRegistry(ctx)
     research = ResearchToolCatalog(ctx, registry, selected_profile)
-    server = Server("mommy-chaogu")
-
     allowed_base = allowed_base_tool_names(selected_profile)
     base_defs = [
         item for item in registry.definitions() if item["function"]["name"] in allowed_base
@@ -180,7 +186,6 @@ def create_mcp_server(
             openWorldHint=name not in {"get_memory_context", "get_prediction_history"},
         )
 
-    @server.list_tools()
     async def list_tools() -> list[Tool]:
         tools: list[Tool] = []
         for td in base_defs:
@@ -204,7 +209,6 @@ def create_mcp_server(
             )
         return tools
 
-    @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any] | None) -> list[TextContent]:
         if name not in allowed_base and name not in allowed_research:
             result = (
@@ -220,7 +224,33 @@ def create_mcp_server(
             result = await asyncio.to_thread(research.call, name, arguments or {})
         return [TextContent(type="text", text=result)]
 
-    return server
+    # MCP Python SDK 2.0 removed the low-level Server decorator API in favour
+    # of constructor callbacks.  Keep both paths because installed uv tools
+    # resolve dependencies independently: existing lockfiles can still use
+    # MCP 1.x while a fresh ``uv tool install`` may resolve MCP 2.x.
+    if hasattr(Server, "list_tools"):
+        server = Server("mommy-chaogu")
+        server.list_tools()(list_tools)  # type: ignore[attr-defined]
+        server.call_tool()(call_tool)  # type: ignore[attr-defined]
+        return server
+
+    async def on_list_tools(
+        _request_context: Any,
+        _params: PaginatedRequestParams | None,
+    ) -> ListToolsResult:
+        return ListToolsResult(tools=await list_tools())
+
+    async def on_call_tool(
+        _request_context: Any,
+        params: CallToolRequestParams,
+    ) -> CallToolResult:
+        return CallToolResult(content=await call_tool(params.name, params.arguments))
+
+    return Server(
+        "mommy-chaogu",
+        on_list_tools=on_list_tools,
+        on_call_tool=on_call_tool,
+    )  # type: ignore[call-overload]
 
 
 async def run_stdio(profile: McpProfile | str = "market-only") -> None:

--- a/src/mommy_chaogu/cli_commands/connect.py
+++ b/src/mommy_chaogu/cli_commands/connect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import importlib.metadata
 import json
 import os
 import shutil
@@ -362,11 +363,23 @@ async def _probe(spec: ConnectionSpec) -> list[str]:
             async with ClientSession(
                 read_stream,
                 write_stream,
-                read_timeout_seconds=timedelta(seconds=15),
+                read_timeout_seconds=_mcp_read_timeout(),
             ) as session:
                 await session.initialize()
                 tools = await session.list_tools()
                 return [tool.name for tool in tools.tools]
+
+
+def _mcp_read_timeout() -> Any:
+    """Return the timeout shape expected by the installed MCP SDK.
+
+    MCP 1.x accepts ``timedelta`` while MCP 2.x changed the same parameter to
+    a numeric seconds value.  ``Any`` is intentional so one source tree can
+    type-check against the locked 1.x SDK and still run in independently
+    resolved uv tool environments using 2.x.
+    """
+    major = int(importlib.metadata.version("mcp").partition(".")[0])
+    return 15.0 if major >= 2 else timedelta(seconds=15)
 
 
 def _probe_sync(spec: ConnectionSpec) -> list[str]:

--- a/tests/test_agent/test_assembly_smoke.py
+++ b/tests/test_agent/test_assembly_smoke.py
@@ -202,3 +202,22 @@ class TestMcpServerSmoke:
         assert "research_portfolio" in tools
         assert "record_research_conclusion" in tools
         assert tools["record_research_conclusion"].annotations.readOnlyHint is False
+
+    def test_mcp_v2_registers_constructor_callbacks(self, isolated_env: Path) -> None:
+        """MCP 2.x 删除装饰器后，工具仍通过构造函数 callback 注册。"""
+        from mommy_chaogu.agent.mcp_server import create_mcp_server
+        from mommy_chaogu.agent.tools.base import ToolContext
+
+        class FakeMcp2Server:
+            def __init__(self, name: str, **handlers: Any) -> None:
+                self.name = name
+                self.handlers = handlers
+
+        ctx = ToolContext(adapter=None, agent_db=isolated_env / "agent.db")  # type: ignore[arg-type]
+        with patch("mommy_chaogu.agent.mcp_server.Server", FakeMcp2Server):
+            server = create_mcp_server(ctx)
+
+        listed = asyncio.run(server.handlers["on_list_tools"](None, None))  # type: ignore[attr-defined]
+        names = {tool.name for tool in listed.tools}
+        assert "get_quote" in names
+        assert "get_portfolio" not in names

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shutil
 import sys
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +12,7 @@ import pytest
 from mommy_chaogu.cli_commands.connect import (
     ConnectionSpec,
     _connection_spec,
+    _mcp_read_timeout,
     _probe_sync,
     build_connect_parser,
     cmd_connect,
@@ -48,6 +50,13 @@ def test_connection_spec_keeps_virtualenv_python_fallback() -> None:
         spec = _connection_spec("market-only")
     assert spec.command == sys.executable
     assert spec.args[:2] == ["-m", "mommy_chaogu.agent.mcp_server"]
+
+
+def test_probe_timeout_matches_mcp_sdk_major_version() -> None:
+    with patch("mommy_chaogu.cli_commands.connect.importlib.metadata.version", return_value="1.28.1"):
+        assert _mcp_read_timeout() == timedelta(seconds=15)
+    with patch("mommy_chaogu.cli_commands.connect.importlib.metadata.version", return_value="2.0.0"):
+        assert _mcp_read_timeout() == 15.0
 
 
 def test_kimi_connect_preserves_other_servers_and_installs_skill(


### PR DESCRIPTION
## What changed

- Register MCP tool handlers through constructor callbacks on MCP 2.x while retaining the MCP 1.x decorator path.
- Adapt the connection probe timeout value to the SDK major version.
- Add regression coverage for MCP 2.x registration and timeout compatibility.

## Why

MCP 2.0 removed the low-level `Server.list_tools()` and `Server.call_tool()` decorators and changed `ClientSession.read_timeout_seconds` from `timedelta` to numeric seconds. Independently resolved `uv tool` installations could therefore fail during `mommy connect kimi` even though the project lockfile still used MCP 1.28.

## Impact

Fresh and existing installations can connect Claude Code or Kimi Code with MCP 1.28 or MCP 2.0. The `market-only` profile continues to exclude portfolio and memory tools.

## Validation

- Real stdio handshake with MCP 1.28.1
- Real stdio handshake with MCP 2.0.0; 19 market-only tools discovered
- `pytest -q tests/test_agent/test_assembly_smoke.py tests/test_connect.py` (16 passed)
- Ruff checks passed
- Strict mypy checks passed
