### PR TITLE
feat(market_data): 集成 AKShare + Tushare 数据源，修复审核发现的正确性问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@
 
 # Web 推送链接前缀
 #WEB_BASE_URL=http://192.168.1.100:8765
+
+# Tushare Pro（A 股金融数据云，海外 IP 友好 — 阿里云）
+# 注册：https://tushare.pro/register
+# 免费档每日 5000 积分；K 线/资金流/财务/分红的主源
+# 不配 = TushareAdapter 自动跳过，fallback 链只走 efinance + tencent (+ akshare)
+#TUSHARE_TOKEN=your_tushare_token_here

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ uv run python scripts/migrate_db_layout.py            # 执行迁移
 
 ```
 src/mommy_chaogu/
-├── market_data/     # 数据源适配层（efinance + tencent + fallback）
+├── market_data/     # 数据源适配层（efinance + tencent + akshare + fallback + builder 工厂）
 ├── cache/           # SQLite 缓存（5 张表 + 节流 + freshness）
 ├── watchlist/       # 自选股（SQLite + SQLAlchemy 2.0）
 ├── monitor/         # 实时监控
@@ -137,7 +137,7 @@ Agent 交互指导见 `docs/AGENT-INTERACTION-GUIDE.md`。
 - **mypy --strict** — 类型检查（豁免模块清单与收敛方向见 `docs/TECH-DEBT.md`）
 - **Conventional Commits** — `feat / fix / docs / refactor / chore`
 - 数据金额一律 `Decimal`，不用 `float`
-- 数据源走 `MarketDataAdapter` Protocol，加新源只实现 Protocol
+- 数据源走 `MarketDataAdapter` Protocol，加新源只实现 Protocol；装配 fallback 链一律调 `market_data.builder.build_default_adapter()`，不要在业务层直接 `FallbackAdapter([...])`（顺序/启停条件由 builder 统一管）
 - provider 配置只改 `agent/llm.py` 的 `SUPPORTED_PROVIDERS`（service/config/backtest/MCP 全部引用它）；LLM client 一律经 `llm.create_client()` 构造（显式 timeout + 关 SDK 内置重试，重试由应用层统一）
 - 新增 agent 工具：在 `agent/tools/` 对应域模块（quote/sector/flows/bars/holdings/intel/alerts/memory/themes）的 `DEFS` 与 `HANDLERS` 各加一项，`registry.py` 自动聚合（import 时校验两边名字一致），无需改注册表
 - 拉新失败保留旧数据（数据库是唯一真相源）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@
 
 ---
 
+## [Unreleased]
+
+### 新增
+
+- **AKShare 数据源集成** — 开源、无 token 的 A 股数据接口库，作为 fallback 链第三档接入（akshare 已安装时启用，否则自动跳过）。定位为**字段补全源**而非故障兜底（与 efinance 共享东财后端，故障同源）。
+  - 新增 `AkShareAdapter` 实现 `MarketDataAdapter` Protocol：
+    - **实时报价**：`stock_zh_a_spot_em` 一次性给 PE/PB/总市值/流通市值/换手率/量比（efinance 单股接口这些字段常缺）
+    - **K 线**：日/周/月走 `stock_zh_a_hist`，分钟走 `stock_zh_a_hist_min_em`，复权直接传 `qfq`/`hfq`/`""`
+    - **资金流**：`stock_individual_fund_flow` 返回 ~100 天，含主力/超大/大/中/小单净额 + 占比
+    - **健康检查**：拉一行 spot
+    - 盘口/逐笔/板块反查有意不实现（akshare 无稳定接口 / 反查太重），留给 efinance 兜底
+  - **装配工厂** `build_default_adapter()`：业务层不再直接 `FallbackAdapter([...])`，统一调工厂。链顺序 `Efinance → Tencent → AkShare`，由工厂集中管。
+  - 9 个生产调用点 + 1 个脚本（CLI/monitor/agent/MCP/TUI/web/flows/cron_verify）已迁移到工厂。
+  - 决策记录见 `docs/adr/0002-akshare-integration.md`。
+
+### 改进
+
+- **akshare 作为可选依赖**：体积大（~100MB），放 `[project.optional-dependencies].dev`，运行时 `builder._akshare_available()` 探测，普通用户 `uv sync` 不被强加这个重量。
+- mypy override 加 `akshare` / `akshare.*`（ignore_missing_imports）。
+
+---
+
 ## [1.1.0] - 2026-07-19
 
 ### 新增

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ### 新增
 
+- **Tushare 数据源集成** — 阿里云金融数据云，海外 IP 友好；K 线/财务三表/资金流/分红最强。详见 `docs/adr/0003-tushare-integration.md`（待补）。仅在 `TUSHARE_TOKEN` 环境变量配置时启用。
+  - 新增 `TushareAdapter` 实现 `MarketDataAdapter` Protocol：
+    - **代码转换**：`to_tushare_code('600519') → '600519.SH'`、`from_tushare_code('600519.SH') → ('600519', MarketType.SH)`
+    - **K 线**：`tushare.pro_bar(adj='qfq'/'hfq')` 一键复权
+    - **财务**：`fina_indicator / income / balance_sheet / cash_flow / dividend / stock_basic` 6 个直连接口
+    - **复权工具**：独立函数 `apply_adjustment(bars, adj_factors, mode)`，可对任意数据源（efinance/腾讯）的不复权价应用 Tushare 复权因子；`TushareAdapter.fetch_and_adjust()` 一键拉取+复权
+  - **`market_data/utils.py`**：抽出 `detect_market()` 统一代码→市场映射（83/87/88/92/40-43 北交所/新三板 + 沪深新 + 沪深基金债券），`efinance` 和 `tushare` 都改用它
+  - **链顺序**：`efinance → tushare → tencent → akshare`（Tushare 放第二位：海外 IP / K 线场景优先；没 token 自动跳过）
+
+### 新增
+
 - **AKShare 数据源集成** — 开源、无 token 的 A 股数据接口库，作为 fallback 链第三档接入（akshare 已安装时启用，否则自动跳过）。定位为**字段补全源**而非故障兜底（与 efinance 共享东财后端，故障同源）。
   - 新增 `AkShareAdapter` 实现 `MarketDataAdapter` Protocol：
     - **实时报价**：`stock_zh_a_spot_em` 一次性给 PE/PB/总市值/流通市值/换手率/量比（efinance 单股接口这些字段常缺）

--- a/docs/BACKEND-CAPABILITIES.md
+++ b/docs/BACKEND-CAPABILITIES.md
@@ -82,7 +82,7 @@ CLI 对照见 §7；完整 REST 契约见 §4；Python 签名见 §6。
 - bars 参数：interval ∈ `1m/5m/15m/30m/60m/1d/1w/1M`；adjustment ∈ `none/forward/backward`；limit ≤ 500
 - **边界**：涨跌榜已过滤 ST/退市/涨跌幅>11%；`get_quote` 未找到返回 404；多空盘接口（orderbook）仅交易时段有数据。
 
-**Fallback 语义**：适配器按 `[东财 → 腾讯]` 顺序逐源尝试，单方法独立 fallback；`FallbackAdapter.stats()` 暴露 `{primary_hits, fallback_hits, all_fail}`（`market_data/fallback_adapter.py`）。前端无需感知，只需展示 `format_source_label()`。
+**Fallback 语义**：适配器按 `[东财 → 腾讯 → AKShare（akshare 已安装时）]` 顺序逐源尝试，单方法独立 fallback；akshare 与东财同后端，定位为**字段补全源**（PE/PB/市值 + 历史资金流 ~100 天）而非故障兜底。装配统一走 `market_data.builder.build_default_adapter()`（详见 `docs/adr/0002`）。`FallbackAdapter.stats()` 暴露 `{primary_hits, fallback_hits, all_fail}`（`market_data/fallback_adapter.py`）。前端无需感知，只需展示 `format_source_label()`。
 
 ### 3.2 资金流（flows）
 
@@ -254,8 +254,10 @@ CLI 对照见 §7；完整 REST 契约见 §4；Python 签名见 §6。
 `src/mommy_chaogu/tui/services/bootstrap.py:Services.bootstrap()`：
 
 ```python
-base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
-adapter = CachedMarketDataAdapter(base, CacheStore(MARKET_DB))
+# 装配统一走 build_default_adapter()，不要直接 FallbackAdapter([...])
+# 链顺序：EfinanceAdapter → TencentAdapter → AkShareAdapter（akshare 已安装时）
+# 详见 docs/adr/0002-akshare-integration.md
+adapter = build_default_adapter(with_cache=True, cache_store=CacheStore(MARKET_DB))
 # adapter: get_quote/get_quotes/get_bars/get_today_money_flow/... + format_source_label()
 watchlist_store = WatchlistStore(PORTFOLIO_DB)
 portfolio_store = PortfolioStore(PORTFOLIO_DB)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -63,7 +63,7 @@ class MarketDataAdapter(Protocol):
 ```
 [DB] ←→ [CachedMarketDataAdapter] ←→ [业务层 (Monitor / Signals)]
               ↓
-       [MarketDataAdapter] (efinance / tencent / mock)
+       [MarketDataAdapter] (efinance / tencent / akshare / mock)
 ```
 
 每条缓存记录带**双时间戳**：
@@ -78,7 +78,7 @@ class MarketDataAdapter(Protocol):
 
 | 层 | 降级策略 |
 |---|---|
-| **数据源层** | `FallbackAdapter([Efinance, Tencent])`：主源失败 → 次源 |
+| **数据源层** | `build_default_adapter()` → `FallbackAdapter([Efinance, Tencent, AkShare])`：主源失败 → 次源 → 字段补全 |
 | **缓存层** | 拉新失败 → 静默返回旧数据 + warning 日志 |
 | **业务层** | 单股拉取失败 → 标 `-`，不中断整批 |
 
@@ -89,13 +89,16 @@ class MarketDataAdapter(Protocol):
 能力以**装饰器**形式叠加，每层独立可测：
 
 ```
-EfinanceAdapter  ←  TencentAdapter
+EfinanceAdapter  ←  TencentAdapter  ←  AkShareAdapter（akshare 已安装时）
        ↓
 FallbackAdapter  ←  任何方法都按顺序 fallback
        ↓
 CachedMarketDataAdapter  ←  加 DB 缓存 + 节流
        ↓
 业务层（Monitor / Signals / CLI）
+
+装配统一走 market_data.builder.build_default_adapter()，
+不要在业务层直接 FallbackAdapter([...])。
 ```
 
 **好处**：
@@ -201,14 +204,18 @@ src/mommy_chaogu/
 - 节流可以降低东财被封 IP 的风险
 **反悔条件**：如果妈妈需要「逐笔」级监控 → 改 30s
 
-### ADR-003: Fallback 链 efinance → tencent
-**日期**：2026-06-27（M2.5）
-**结论**：efinance 优先，tencent 兜底
+### ADR-003: Fallback 链 efinance → tencent → akshare
+**日期**：2026-06-27（M2.5），2026-07-25 扩展
+**结论**：efinance 优先，tencent 兜底，akshare 字段补全
 **原因**：
-- efinance 数据更全（K线/资金流/板块）
-- tencent 在 efinance 挂时稳定（凌晨实战验证）
-- 腾讯的 5 档盘口直接嵌在行情里，少一次 HTTP
-**代价**：tencent 不支持 K线/资金流/板块 → 这些方法在 tencent 永远走 efinance
+- efinance 数据最全（K线/资金流/板块）
+- tencent 在 efinance 挂时稳定（凌晨实战验证），5 档盘口直接嵌在行情里
+- akshare 与 efinance 共享东财后端（非故障兜底），但 `stock_zh_a_spot_em`
+  的 PE/PB/市值字段更稳，资金流接口历史更全（~100 天）
+**代价**：
+- tencent 不支持 K线/资金流/板块 → 这些方法永远走 efinance/akshare
+- akshare 依赖体积大（~100MB），放 dev extra，运行时探测未安装则跳过
+**装配**：统一走 `market_data.builder.build_default_adapter()`（详见 `docs/adr/0002`）
 
 ### ADR-004: SQLite + SQLAlchemy 2.0 async
 **日期**：2026-06-26（M1）

--- a/docs/DETAILED-ARCHITECTURE.md
+++ b/docs/DETAILED-ARCHITECTURE.md
@@ -250,9 +250,10 @@ mommy flows pull --pool semicon --days 30
 |---|---|---|
 | **东方财富 (efinance)** | 主力数据源（行情 / K 线 / 资金流 / 业绩） | `ef.stock.*` |
 | **腾讯财经 (Tencent)** | 备援（行情） | `qt.gtimg.cn` |
+| **AKShare** | 字段补全（PE/PB/市值、历史资金流 ~100 天、备援 K 线） | `ak.stock_zh_a_spot_em` 等 |
 | **巨潮资讯 (cninfo)** | 公告日历 | `hisAnnouncement/query` |
 
-多源 fallback 链：`CachedMarketDataAdapter(FallbackAdapter([EfinanceAdapter, TencentAdapter]))`
+多源 fallback 链：`build_default_adapter()` → `CachedMarketDataAdapter(FallbackAdapter([EfinanceAdapter, TencentAdapter, AkShareAdapter]))`（akshare 未安装时自动跳过）。详见 `docs/adr/0002`。
 
 ---
 
@@ -261,7 +262,7 @@ mommy flows pull --pool semicon --days 30
 ```
 mommy-chaogu/
 ├── src/mommy_chaogu/
-│   ├── market_data/         # 数据源适配层（efinance + tencent + fallback）
+│   ├── market_data/         # 数据源适配层（efinance + tencent + akshare + fallback + builder 工厂）
 │   ├── cache/               # SQLite 缓存（5 表 + 节流 + freshness）
 │   ├── watchlist/           # 自选股 ORM（SQLAlchemy 2.0）
 │   ├── monitor/             # 实时监控

--- a/docs/adr/0002-akshare-integration.md
+++ b/docs/adr/0002-akshare-integration.md
@@ -1,0 +1,85 @@
+# ADR 0002: AKShare 数据源集成（第一步 + 第二步）
+
+- Status: Accepted
+- Date: 2026-07-25
+
+## Context
+
+行情数据层原先只有 `EfinanceAdapter`（主源）+ `TencentAdapter`（实时报价兜底）。两者
+通过 `FallbackAdapter` 串联。efinance 走东财 `push2his.eastmoney.com`，单股 `get_quote`
+字段经常缺 PE/PB/市值；腾讯只给报价不给 K 线。
+
+考虑过 Tushare（见被拒的 `tushare-integration.patch`），但 Tushare 需要 token + 2000 积分，
+且 patch 里有三个阻塞性 bug（`Money * Decimal` 崩溃、`moneyflow` 字段名捏造、
+provider 配置改动与 `llm.py` 单一真相源重组冲突）。
+
+AKShare 是开源、无 token、走东财 + 新浪等多源后端的库，`stock_zh_a_spot_em` 一次性给
+PE/PB/总市值/流通市值/换手率/量比，是 efinance 单股接口的字段补全源。
+
+## Decision
+
+把 AKShare 作为 fallback 链的**第三档**接入，定位为"字段补全源"而非"故障兜底"：
+
+```
+EfinanceAdapter (主源)  →  TencentAdapter (异构兜底)  →  AkShareAdapter (字段补全)
+```
+
+**为什么 akshare 不是主源或故障兜底**：它和 efinance 都走东财后端，东财挂的时候两个
+一起挂——真正的故障多样性在 东财 ↔ 腾讯 这条轴上。akshare 的增量价值是字段更全的
+`stock_zh_a_spot_em` 和另一条 K 线实现路径（`stock_zh_a_hist`）。
+
+### 第一步实现范围（最小可用）
+
+只实现覆盖 90% 场景的三个方法，其余返回空让 fallback 链接管：
+
+| 方法 | akshare 函数 | 备注 |
+|---|---|---|
+| `list_market_quotes` / `get_quote` / `get_quotes` | `stock_zh_a_spot_em` | 全市场一次拉取再过滤 |
+| `get_bars`（日/周/月） | `stock_zh_a_hist(symbol, period, start_date, end_date, adjust)` | 复权直接传 qfq/hfq/"" |
+| `get_bars`（分钟） | `stock_zh_a_hist_min_em(...)` | 只能返回近期数据 |
+| `health_check` | `stock_zh_a_spot_em` 拉一行 | |
+
+**第一步不实现**（返回空，留给 efinance/腾讯）：`get_order_book` / `get_ticks` /
+`get_belonging_boards`。
+
+### 第二步实现范围（资金流）
+
+| 方法 | akshare 函数 | 备注 |
+|---|---|---|
+| `get_today_money_flow` | `stock_individual_fund_flow(stock, market)` 取首行 | 盘后更新 |
+| `get_history_money_flow` | 同上（接口给 ~100 天） | 客户端按 `days` 截断 |
+
+字段映射（来自 akshare 源码 `stock_fund_em.py:52-68`，非文档）：
+`主力净流入-净额` / `主力净流入-净占比` / `超大单净流入-净额` /
+`大单净流入-净额` / `中单净流入-净额` / `小单净流入-净额`。
+接口的 `market` 参数（sh/sz/bj）由代码头推断。
+
+**板块反查仍返回空**：akshare 没有"单股 → 所属板块"的直接接口，反查要遍历所有
+板块成分股（~200 次 HTTP），太重。efinance.get_belong_board 是单股直查（1 次 HTTP），
+已在 fallback 链里兜底，akshare 在这里没有增量价值。
+
+### 工厂模式：`build_default_adapter()`
+
+新增 `market_data/builder.py`，业务层不再直接写
+`FallbackAdapter([EfinanceAdapter(), TencentAdapter()])`，统一调
+`build_default_adapter(with_cache=True, cache_store=...)`。
+
+未来调整顺序、加源、改链都只动这一个文件。已迁移 9 个生产调用点 + 1 个脚本
+（CLI / monitor / agent / MCP / TUI / web / flows / cron_verify）。
+
+### akshare 作为可选依赖
+
+akshare 体积大（~100MB，拉 mini-racer / lxml / decoractor 等），不放进主依赖。
+放在 `[project.optional-dependencies].dev` 里。`builder._akshare_available()` 在运行时
+探测，没装就跳过——普通用户 `uv sync` 不会被强加这个重量。
+
+## Consequences
+
+- **正向**：实时报价字段补全（PE/PB/市值不再常缺）；K 线多一条实现路径；
+  业务层装配点统一，未来加源成本降低。
+- **负向**：开发依赖体积增加 ~100MB（只在 dev extra）；
+  akshare 版本飘移时 `stock_zh_a_hist` 可能 KeyError（已在每个方法 try/except 兜住）；
+  akshare 列名是中文（与 efinance 同约定，版本变了立刻 KeyError 暴露反而稳）。
+- **不做的事**：不在 Protocol 上塞财务报表接口（`stock_financial_*`）。
+  Protocol 是为行情设计的；财务数据应像 semicon 模块做成独立参考库服务。
+  这也是被拒 Tushare patch 的设计问题之一。

--- a/docs/adr/0003-tushare-integration.md
+++ b/docs/adr/0003-tushare-integration.md
@@ -1,0 +1,57 @@
+# ADR 0003: Tushare 数据源集成
+
+- Status: Accepted
+- Date: 2026-07-31
+
+## Context
+
+ADR 0002 时曾评估过 Tushare（`tushare-integration.patch`），当时因三个阻塞性 bug
+拒绝：`Money * Decimal` 崩溃、`moneyflow` 字段名捏造、provider 配置与 `llm.py`
+单一真相源冲突。
+
+Tushare 的价值仍在：财务三表/分红/历史 K 线业内最全，且服务部署在阿里云，
+**海外 IP 直连稳定**——efinance/腾讯/akshare 对境外用户都不友好。本次重新集成，
+并在代码审核中对照 tushare.pro 官方文档修掉了上一轮遗留的正确性问题。
+
+## Decision
+
+把 Tushare 作为 fallback 链的**第三档**接入，定位为"EOD 强项源"：
+
+```
+EfinanceAdapter (主源) → TencentAdapter (实时异构兜底) → TushareAdapter (EOD 强项) → AkShareAdapter (字段补全)
+```
+
+**为什么排在腾讯之后**：`TushareAdapter.get_quote` 返回的是 daily + daily_basic
+合成的 EOD 快照（最早可能滞后 30 天）。若排在腾讯之前，efinance 挂掉时会被这份
+过期快照截胡，真正的实时异构兜底永远轮不到。EOD 快照只在 东财+腾讯 同时失败时
+才有价值（境外场景）。
+
+**仅在有 token 时启用**：`TUSHARE_TOKEN` 未配置则 `is_available=False`，builder
+自动跳过，不进入链。
+
+### 接口范围与关键约定
+
+| 方法 | Tushare 接口 | 关键约定 |
+|---|---|---|
+| `get_quote` / `get_quotes` | daily + daily_basic 合成 | EOD 快照；amount 单位**千元** ×1000；市值万元 ×10000 |
+| `get_bars`（日/周/月） | pro_bar(adj=qfq/hfq/None) | **分钟线不支持**（stk_mins 需单独权限，且 pro_bar 在 adj≠None 时 drop trade_date 列） |
+| `get_today/history_money_flow` | moneyflow | 需 2000 积分；只覆盖沪深；amount 单位**万元** ×10000；四档净流入 = buy_xx − sell_xx 自算 |
+| 财务三表/分红/指标 | income/balancesheet/cashflow/dividend/fina_indicator | 返回原始 dict，键名与 Tushare 一致 |
+| `get_order_book` / `get_ticks` / `get_belonging_boards` / `list_market_quotes` | — | 返回空，交给链上其它源 |
+
+### 复权公式（与 pro_bar 对齐）
+
+Tushare `adj_factor` 上市首日 = 1，随分红送股**递增**（越晚越大）。因此：
+
+- 前复权：`price × cur_factor / latest_factor`（最新价不变，历史价压低）
+- 后复权：`price × cur_factor / earliest_factor`（最早价不变）
+
+`apply_adjustment` 曾因"因子越早越大"的错误假设把两个公式写反，本轮已修正，
+测试 fixture 改为使用递增因子的真实语义。
+
+## Consequences
+
+- K 线/资金流/财务数据在海外 IP 下可用，且复权价与 Tushare 官方一致
+- 成交额/资金流金额与 efinance 一样统一为**元**（Decimal），跨源量纲一致
+- moneyflow/adj_factor 需 2000 积分，积分不足时静默降级为空——需自行在
+  tushare.pro 后台确认积分等级

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "mypy>=1.11",
     "types-requests",
     "httpx>=0.27",  # FastAPI 测试客户端
+    "akshare>=1.18",  # AkShareAdapter 数据源（运行时按需启用，测试需要）
 ]
 
 [build-system]
@@ -80,6 +81,7 @@ module = [
     "efinance", "pandas", "pandas.*", "rich", "retry", "tqdm", "multitasking",
     "jsonpath", "requests", "requests.*",
     "sqlalchemy", "sqlalchemy.*",
+    "akshare", "akshare.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "sqlite-vec>=0.1.9",
     "python-dotenv>=1.0",
     "textual>=8.2.8",
+    "tushare>=1.4.29",
 ]
 
 [project.scripts]
@@ -82,6 +83,7 @@ module = [
     "jsonpath", "requests", "requests.*",
     "sqlalchemy", "sqlalchemy.*",
     "akshare", "akshare.*",
+    "tushare", "tushare.*",
 ]
 ignore_missing_imports = true
 

--- a/scripts/cron_verify.py
+++ b/scripts/cron_verify.py
@@ -58,21 +58,16 @@ def run_verify(db_path: Path, logger: logging.Logger) -> dict[str, int]:
     from mommy_chaogu.agent.episodic_memory import EpisodicMemory
     from mommy_chaogu.agent.prediction_tracker import PredictionTracker
     from mommy_chaogu.agent.verify_engine import verify_pending
-    from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+    from mommy_chaogu.cache import CacheStore
     from mommy_chaogu.db_paths import MARKET_DB
-    from mommy_chaogu.market_data import (
-        EfinanceAdapter,
-        FallbackAdapter,
-        TencentAdapter,
-    )
+    from mommy_chaogu.market_data import build_default_adapter
 
     tracker = PredictionTracker(db_path)
     episodic = EpisodicMemory(db_path)
 
     # 行情缓存属于 market.db（与缓存层读取一致），不写进 agent.db
     store = CacheStore(MARKET_DB)
-    base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
-    adapter = CachedMarketDataAdapter(base, store)
+    adapter = build_default_adapter(with_cache=True, cache_store=store)
 
     logger.info("🔍 验证到期预测...")
     logger.info("%s", "─" * 60)

--- a/src/mommy_chaogu/agent/mcp_server.py
+++ b/src/mommy_chaogu/agent/mcp_server.py
@@ -59,15 +59,14 @@ def _build_llm() -> tuple[Any | None, str | None, str | None]:
 
 def _build_context() -> ToolContext:
     """从项目默认配置构造 ToolContext（含记忆服务 + LLM client）。"""
-    from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+    from mommy_chaogu.cache import CacheStore
     from mommy_chaogu.db_paths import AGENT_DB, MARKET_DB, PORTFOLIO_DB
-    from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+    from mommy_chaogu.market_data import build_default_adapter
     from mommy_chaogu.portfolio.store import PortfolioStore
     from mommy_chaogu.watchlist.store import WatchlistStore
 
-    base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
     store = CacheStore(MARKET_DB)
-    adapter = CachedMarketDataAdapter(base, store)
+    adapter = build_default_adapter(with_cache=True, cache_store=store)
 
     client, model, embedding_model = _build_llm()
 

--- a/src/mommy_chaogu/cache/manager.py
+++ b/src/mommy_chaogu/cache/manager.py
@@ -20,12 +20,14 @@ class CacheManager:
 
     @classmethod
     def default(cls, db_path: Path, config: CacheConfig | None = None) -> CacheManager:
-        """默认构造：EfinanceAdapter + CacheStore + CachedMarketDataAdapter。"""
-        from mommy_chaogu.cache.adapter import CachedMarketDataAdapter
-        from mommy_chaogu.market_data import EfinanceAdapter
+        """默认构造：CacheStore + CachedMarketDataAdapter(fallback 链 + 缓存)。
+
+        fallback 链顺序：Efinance → Tushare（需 TUSHARE_TOKEN）→ Tencent → AkShare。
+        """
+        from mommy_chaogu.market_data import build_default_adapter
 
         store = CacheStore(db_path)
-        adapter = CachedMarketDataAdapter(EfinanceAdapter(), store, config=config)
+        adapter = build_default_adapter(with_cache=True, cache_store=store, cache_config=config)
         return cls(store, adapter)
 
     # ---------- warmup ----------

--- a/src/mommy_chaogu/cli.py
+++ b/src/mommy_chaogu/cli.py
@@ -328,18 +328,17 @@ def main_mommy() -> NoReturn:
 
     # 构建工具链
     from mommy_chaogu.agent.tools import ToolContext, ToolRegistry
-    from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+    from mommy_chaogu.cache import CacheStore
     from mommy_chaogu.db_paths import AGENT_DB, MARKET_DB, PORTFOLIO_DB
-    from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+    from mommy_chaogu.market_data import build_default_adapter
     from mommy_chaogu.portfolio.store import PortfolioStore
     from mommy_chaogu.watchlist.store import WatchlistStore
     from mommy_chaogu.workflow.engine import WorkflowExecutor
     from mommy_chaogu.workflow.definitions import get_default_registry
     from mommy_chaogu.workflow.router import NLRouter
 
-    base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
     store = CacheStore(MARKET_DB)
-    adapter = CachedMarketDataAdapter(base, store)
+    adapter = build_default_adapter(with_cache=True, cache_store=store)
     ctx = ToolContext(
         adapter=adapter,
         watchlist_store=WatchlistStore(PORTFOLIO_DB),

--- a/src/mommy_chaogu/cli_commands/agent.py
+++ b/src/mommy_chaogu/cli_commands/agent.py
@@ -44,15 +44,14 @@ def build_agent_parser() -> argparse.ArgumentParser:
 def _build_agent_context() -> object:
     """从项目默认配置构造 agent ToolContext。"""
     from mommy_chaogu.agent.tools import ToolContext
-    from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+    from mommy_chaogu.cache import CacheStore
     from mommy_chaogu.db_paths import AGENT_DB, MARKET_DB, PORTFOLIO_DB
-    from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+    from mommy_chaogu.market_data import build_default_adapter
     from mommy_chaogu.portfolio.store import PortfolioStore
     from mommy_chaogu.watchlist.store import WatchlistStore
 
-    base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
     store = CacheStore(MARKET_DB)
-    adapter = CachedMarketDataAdapter(base, store)
+    adapter = build_default_adapter(with_cache=True, cache_store=store)
 
     return ToolContext(
         adapter=adapter,
@@ -103,16 +102,15 @@ def run_verify(db: Path, market_db: Path | None = None) -> dict[str, int]:
     from mommy_chaogu.agent.episodic_memory import EpisodicMemory
     from mommy_chaogu.agent.prediction_tracker import PredictionTracker
     from mommy_chaogu.agent.verify_engine import verify_pending
-    from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+    from mommy_chaogu.cache import CacheStore
     from mommy_chaogu.db_paths import MARKET_DB
-    from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+    from mommy_chaogu.market_data import build_default_adapter
 
     tracker = PredictionTracker(db)
     episodic = EpisodicMemory(db)
 
     store = CacheStore(market_db or MARKET_DB)
-    base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
-    adapter = CachedMarketDataAdapter(base, store)
+    adapter = build_default_adapter(with_cache=True, cache_store=store)
 
     return verify_pending(
         tracker=tracker,

--- a/src/mommy_chaogu/cli_commands/monitor.py
+++ b/src/mommy_chaogu/cli_commands/monitor.py
@@ -12,17 +12,16 @@ from mommy_chaogu.cli_support import *
 
 
 def _make_adapter(args: argparse.Namespace) -> object:
-    """构造 adapter，默认用 fallback + 缓存包装。
+    """构造 adapter，默认用 fallback 链 + 缓存包装。
 
-    顺序：EfinanceAdapter (主) → TencentAdapter (fallback) → CachedMarketDataAdapter (外层)
-    东财接口挂了 → 自动降级到腾讯财经（数据稳定）
+    顺序：EfinanceAdapter → TencentAdapter → AkShareAdapter（已安装时）
+    → CachedMarketDataAdapter (外层)。东财接口挂了自动降级。
     """
-    from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
-    from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+    from mommy_chaogu.cache import CacheStore
+    from mommy_chaogu.market_data import build_default_adapter
 
-    base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])
     store = CacheStore(Path(args.db))
-    return CachedMarketDataAdapter(base, store)
+    return build_default_adapter(with_cache=True, cache_store=store)
 
 
 def cmd_monitor_snapshot(args: argparse.Namespace) -> int:

--- a/src/mommy_chaogu/flows/service.py
+++ b/src/mommy_chaogu/flows/service.py
@@ -104,20 +104,21 @@ class FlowService:
         *,
         use_fallback: bool = True,
     ) -> FlowService:
-        """默认构造：CacheStore + CachedMarketDataAdapter(Efinance + Tencent fallback)。"""
-        from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
-        from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+        """默认构造：CacheStore + CachedMarketDataAdapter(fallback 链 + 缓存)。"""
+        from mommy_chaogu.cache import CacheStore
+        from mommy_chaogu.market_data import build_default_adapter
 
         store = CacheStore(db_path)
-        # base 必须是 MarketDataAdapter Protocol，但 TencentAdapter.get_bars 用了 **kw，
-        # 跟 Protocol 里强类型签名不一致（运行时兼容）。所以这里统一用 Any 转一道。
-        base: Any
         if use_fallback:
-            base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])  # type: ignore[list-item]
+            # build_default_adapter(with_cache=True) 返回的其实是 CachedMarketDataAdapter，
+            # 但工厂签名返回 MarketDataAdapter Protocol，这里收窄一道满足类型。
+            adapter = build_default_adapter(with_cache=True, cache_store=store)
         else:
-            base = EfinanceAdapter()
-        adapter = CachedMarketDataAdapter(base, store)
-        return cls(adapter, store)
+            from mommy_chaogu.cache import CachedMarketDataAdapter
+            from mommy_chaogu.market_data import EfinanceAdapter
+
+            adapter = CachedMarketDataAdapter(EfinanceAdapter(), store)
+        return cls(adapter, store)  # type: ignore[arg-type]
 
     # ============================================================
     # 拉新

--- a/src/mommy_chaogu/market_data/__init__.py
+++ b/src/mommy_chaogu/market_data/__init__.py
@@ -5,6 +5,8 @@ from mommy_chaogu.market_data.adapter import (
     filter_by_market,
     find_quote,
 )
+from mommy_chaogu.market_data.akshare_adapter import AkShareAdapter
+from mommy_chaogu.market_data.builder import build_default_adapter
 from mommy_chaogu.market_data.efinance_adapter import EfinanceAdapter
 from mommy_chaogu.market_data.fallback_adapter import FallbackAdapter
 from mommy_chaogu.market_data.tencent_adapter import TencentAdapter
@@ -25,6 +27,7 @@ from mommy_chaogu.market_data.types import (
 
 __all__ = [
     "AdjustmentType",
+    "AkShareAdapter",
     "Bar",
     "BarInterval",
     "Board",
@@ -40,6 +43,7 @@ __all__ = [
     "QuoteType",
     "TencentAdapter",
     "Tick",
+    "build_default_adapter",
     "filter_by_market",
     "find_quote",
 ]

--- a/src/mommy_chaogu/market_data/__init__.py
+++ b/src/mommy_chaogu/market_data/__init__.py
@@ -10,6 +10,12 @@ from mommy_chaogu.market_data.builder import build_default_adapter
 from mommy_chaogu.market_data.efinance_adapter import EfinanceAdapter
 from mommy_chaogu.market_data.fallback_adapter import FallbackAdapter
 from mommy_chaogu.market_data.tencent_adapter import TencentAdapter
+from mommy_chaogu.market_data.tushare_adapter import (
+    TushareAdapter,
+    apply_adjustment,
+    from_tushare_code,
+    to_tushare_code,
+)
 from mommy_chaogu.market_data.types import (
     AdjustmentType,
     Bar,
@@ -24,6 +30,7 @@ from mommy_chaogu.market_data.types import (
     QuoteType,
     Tick,
 )
+from mommy_chaogu.market_data.utils import detect_market
 
 __all__ = [
     "AdjustmentType",
@@ -43,7 +50,12 @@ __all__ = [
     "QuoteType",
     "TencentAdapter",
     "Tick",
+    "TushareAdapter",
+    "apply_adjustment",
     "build_default_adapter",
+    "detect_market",
     "filter_by_market",
     "find_quote",
+    "from_tushare_code",
+    "to_tushare_code",
 ]

--- a/src/mommy_chaogu/market_data/akshare_adapter.py
+++ b/src/mommy_chaogu/market_data/akshare_adapter.py
@@ -16,7 +16,7 @@
 第一步实现范围（最小可用）：
 - ``list_market_quotes`` / ``get_quote`` / ``get_quotes``：走 ``stock_zh_a_spot_em``
 - ``get_bars``：日/周/月走 ``stock_zh_a_hist``，分钟走 ``stock_zh_a_hist_min_em``
-- ``health_check``：拉一行 spot
+- ``health_check``：单股基本信息接口（``stock_individual_info_em``）
 
 其余方法返回 None/[] 让 fallback 接管（资金流 / 板块 / 盘口 / tick）。
 """
@@ -466,12 +466,18 @@ class AkShareAdapter:
         return flows
 
     def get_today_money_flow(self, code: str) -> list[MoneyFlow]:
-        """当日资金流：取接口返回的最新一行（盘后更新）。"""
+        """当日资金流：取接口返回的最新一行（盘后更新）。
+
+        akshare 的 ``stock_individual_fund_flow`` 走东财 klines 端点，返回的是
+        **升序**（最早在前，源码 stock_fund_em.py 不重新排序），所以不能用
+        ``iloc[0]``。这里显式取 ``日期`` 最大那行，不依赖输入顺序，防止上游
+        字段/排序漂移导致取到 ~100 天前的旧行。
+        """
         df = self._fetch_fund_flow_df(code)
         if df is None:
             return []
         try:
-            latest = df.iloc[0:1]  # akshare 默认降序，最新在前
+            latest = df.sort_values("日期", ascending=False).iloc[0:1]
         except Exception:
             return []
         return self._fund_flow_df_to_flows(latest, code)
@@ -499,6 +505,16 @@ class AkShareAdapter:
     # ---------- 健康检查 ----------
 
     def health_check(self) -> bool:
-        """拉一行 spot，能拿到就算 OK。"""
-        df = self._fetch_spot_df()
-        return df is not None
+        """轻量健康检查：单股基本信息接口（1 次 HTTP），不拉全市场 spot。
+
+        用 ``stock_individual_info_em(symbol="600519")`` 探测——单股静态信息，
+        比 ``stock_zh_a_spot_em``（全市场 5000+ 行、1-3 秒）快得多，适合启动 /
+        心跳场景。
+        """
+        try:
+            ak = _safe_akshare()
+            df = ak.stock_individual_info_em(symbol="600519")
+        except Exception as e:
+            _log.debug("akshare health_check failed: %s", e)
+            return False
+        return df is not None and not df.empty

--- a/src/mommy_chaogu/market_data/akshare_adapter.py
+++ b/src/mommy_chaogu/market_data/akshare_adapter.py
@@ -1,0 +1,504 @@
+"""AKShare 数据源实现（开源、无 token）。
+
+定位（详见 docs/ADR/akshare-integration）：
+- 与 efinance **共享东财后端**（push2his.eastmoney.com），所以不是 efinance
+  的故障兜底（东财挂的时候 akshare 也挂），而是**字段补全源**：
+  - ``stock_zh_a_spot_em`` 一次性给 PE/PB/总市值/流通市值/换手率/量比，efinance
+    单股接口这些字段经常缺
+  - 实时报价的字段权威性比 efinance 单股接口高
+- fallback 链里放在 efinance + tencent **之后**，只在前面都失败/字段缺失时补位。
+
+为什么 akshare 不是第一选择：
+- 依赖体积大（~100MB，拉 decoractor / xlrd / minio 等一堆东西）
+- 接口函数多（~3000 个），版本飘移时字段会变，列名是中文
+- ``stock_zh_a_hist`` 是 KeyError 重灾区（akfamily/akshare 一堆 issue）
+
+第一步实现范围（最小可用）：
+- ``list_market_quotes`` / ``get_quote`` / ``get_quotes``：走 ``stock_zh_a_spot_em``
+- ``get_bars``：日/周/月走 ``stock_zh_a_hist``，分钟走 ``stock_zh_a_hist_min_em``
+- ``health_check``：拉一行 spot
+
+其余方法返回 None/[] 让 fallback 接管（资金流 / 板块 / 盘口 / tick）。
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import pandas as pd
+
+from mommy_chaogu.market_data.types import (
+    AdjustmentType,
+    Bar,
+    BarInterval,
+    Board,
+    MarketType,
+    Money,
+    MoneyFlow,
+    OrderBook,
+    Quote,
+    QuoteType,
+    Tick,
+)
+
+_log = logging.getLogger(__name__)
+
+
+# ---------- 内部工具（与 efinance/tencent adapter 同约定）----------
+
+
+def _to_dec(v: Any) -> Decimal | None:
+    """安全转 Decimal，失败/NaN 返回 None。"""
+    if v is None:
+        return None
+    if isinstance(v, float) and pd.isna(v):
+        return None
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _to_int(v: Any) -> int:
+    """安全转 int。"""
+    if v is None or (isinstance(v, float) and pd.isna(v)):
+        return 0
+    try:
+        return int(float(v))
+    except (ValueError, TypeError):
+        return 0
+
+
+def _to_money(v: Any) -> Money:
+    """转 Money（默认 CNY）。"""
+    amt = _to_dec(v) or Decimal("0")
+    return Money(amt, "CNY")
+
+
+def _detect_market(code: str) -> MarketType:
+    """根据 6 位代码头推断市场（与 efinance_adapter 一致）。"""
+    if code.startswith(("60", "68")):
+        return MarketType.SH
+    if code.startswith("9"):
+        return MarketType.BJ
+    if code.startswith(("00", "30")):
+        return MarketType.SZ
+    if code.startswith(("51", "15", "16", "18")):
+        return MarketType.SH
+    if code.startswith(("11", "12", "13", "14")):
+        return MarketType.SZ
+    if code.startswith(("4", "8")):
+        return MarketType.BJ
+    return MarketType.UNKNOWN
+
+
+def _detect_quote_type(code: str) -> QuoteType:
+    if code.startswith(("51", "15", "16", "18", "11", "12", "13", "14")):
+        return QuoteType.FUND
+    return QuoteType.STOCK
+
+
+# 复权方式 → akshare adjust 参数
+_ADJ_MAP: dict[AdjustmentType, str] = {
+    AdjustmentType.NONE: "",
+    AdjustmentType.FORWARD: "qfq",
+    AdjustmentType.BACKWARD: "hfq",
+}
+
+# K 线周期 → akshare period（日/周/月）
+_PERIOD_DWM: dict[BarInterval, str] = {
+    BarInterval.D1: "daily",
+    BarInterval.W1: "weekly",
+    BarInterval.M: "monthly",
+}
+
+# K 线周期 → akshare 分钟 period（字符串）
+_PERIOD_MIN: dict[BarInterval, str] = {
+    BarInterval.M1: "1",
+    BarInterval.M5: "5",
+    BarInterval.M15: "15",
+    BarInterval.M30: "30",
+    BarInterval.M60: "60",
+}
+
+
+def _safe_akshare() -> Any:
+    """延迟 import akshare（避免冷启动 / 未装时整个包加载失败）。
+
+    失败抛 ImportError，调用方在 try/except 里转成空返回。
+    """
+    import akshare as ak
+
+    return ak
+
+
+# ---------- Adapter 实现 ----------
+
+
+class AkShareAdapter:
+    """基于 AKShare 的行情数据源（东财 + 新浪等多源后端，无 token）。
+
+    强项：实时全市场快照字段全（PE/PB/市值/换手率/量比）、日/周/月/分钟 K 线、
+          历史资金流（~100 天，含主力/超大/大/中/小单净额 + 占比）。
+    弱项：逐笔/盘口（akshare 无稳定接口）、板块成分反查（要遍历全市场太重，
+          efinance.get_belong_board 单股直查已足够）。
+    """
+
+    name = "akshare"
+
+    # ---------- 内部：spot 行 → Quote ----------
+
+    def _spot_row_to_quote(self, row: pd.Series) -> Quote | None:
+        """``stock_zh_a_spot_em`` 的一行 → Quote。
+
+        列名是中文，akshare 版本飘移时可能 KeyError，统一在调用方 try/except。
+        """
+        code = str(row.get("代码", "")).strip()
+        if not code:
+            return None
+
+        name = str(row.get("名称", ""))
+        market = _detect_market(code)
+        quote_type = _detect_quote_type(code)
+
+        return Quote(
+            code=code,
+            name=name,
+            market=market,
+            quote_type=quote_type,
+            price=_to_dec(row.get("最新价")) or Decimal("0"),
+            open=_to_dec(row.get("今开")) or Decimal("0"),
+            high=_to_dec(row.get("最高")) or Decimal("0"),
+            low=_to_dec(row.get("最低")) or Decimal("0"),
+            prev_close=_to_dec(row.get("昨收")) or Decimal("0"),
+            change=_to_dec(row.get("涨跌额")) or Decimal("0"),
+            change_pct=_to_dec(row.get("涨跌幅")) or Decimal("0"),
+            volume=_to_int(row.get("成交量")),
+            turnover=_to_money(row.get("成交额")),
+            turnover_rate=_to_dec(row.get("换手率")),
+            volume_ratio=_to_dec(row.get("量比")),
+            pe_dynamic=_to_dec(row.get("市盈率-动态")),
+            total_market_cap=_to_money(row.get("总市值"))
+            if _to_dec(row.get("总市值")) is not None
+            else None,
+            circulating_market_cap=_to_money(row.get("流通市值"))
+            if _to_dec(row.get("流通市值")) is not None
+            else None,
+            timestamp=datetime.now(),
+            extra={"source": "akshare_spot_em"},
+        )
+
+    def _fetch_spot_df(self) -> pd.DataFrame | None:
+        """拉全市场 spot，失败返回 None。"""
+        try:
+            ak = _safe_akshare()
+            df = ak.stock_zh_a_spot_em()
+        except Exception as e:
+            _log.debug("akshare stock_zh_a_spot_em failed: %s", e)
+            return None
+        if df is None or df.empty:
+            return None
+        return df
+
+    # ---------- 实时报价 ----------
+
+    def get_quote(self, code: str) -> Quote | None:
+        """单股：从全市场 spot 过滤一条。
+
+        akshare 没有干净的单股实时接口（``stock_individual_info_em`` 是静态基本信息，
+        不是实时报价），所以单股也走全市场。配合 CachedMarketDataAdapter 层，
+        多次单股调用会被缓存复用同一次全市场拉取。
+        """
+        df = self._fetch_spot_df()
+        if df is None:
+            return None
+        try:
+            row = df[df["代码"] == code]
+        except KeyError:
+            return None
+        if row.empty:
+            return None
+        try:
+            return self._spot_row_to_quote(row.iloc[0])
+        except Exception as e:
+            _log.debug("akshare get_quote(%s) row mapping failed: %s", code, e)
+            return None
+
+    def get_quotes(self, codes: list[str]) -> list[Quote]:
+        """批量：一次全市场 + 过滤。比循环单股快。"""
+        df = self._fetch_spot_df()
+        if df is None:
+            return []
+        try:
+            code_set = set(dict.fromkeys(codes))  # 去重保持顺序
+            mask = df["代码"].isin(code_set)
+            subset = df[mask]
+        except KeyError:
+            return []
+
+        out: list[Quote] = []
+        seen: set[str] = set()
+        for _, row in subset.iterrows():
+            try:
+                q = self._spot_row_to_quote(row)
+            except Exception:
+                continue
+            if q is not None and q.code not in seen:
+                out.append(q)
+                seen.add(q.code)
+        return out
+
+    def list_market_quotes(self) -> list[Quote]:
+        """全市场实时快照（~5000 条）。akshare 最强项。"""
+        df = self._fetch_spot_df()
+        if df is None:
+            return []
+        out: list[Quote] = []
+        for _, row in df.iterrows():
+            try:
+                q = self._spot_row_to_quote(row)
+            except Exception:
+                continue
+            if q is not None:
+                out.append(q)
+        return out
+
+    # ---------- 盘口（第一步不实现）----------
+
+    def get_order_book(self, code: str) -> OrderBook | None:
+        """akshare 没有干净的 5 档盘口接口，留给 efinance/tencent。"""
+        return None
+
+    # ---------- K 线 ----------
+
+    def get_bars(
+        self,
+        code: str,
+        interval: BarInterval = BarInterval.D1,
+        adjustment: AdjustmentType = AdjustmentType.FORWARD,
+        start: date | None = None,
+        end: date | None = None,
+        limit: int | None = None,
+    ) -> list[Bar]:
+        """拉 K 线。
+
+        - 日/周/月：``stock_zh_a_hist(symbol, period, start_date, end_date, adjust)``
+        - 分钟：``stock_zh_a_hist_min_em(symbol, start_date, end_date, period, adjust)``
+          注意 akshare 分钟线只能返回近期数据（1 分钟只有当日，其余近几个交易日）。
+
+        复权直接通过 akshare 的 ``adjust`` 参数处理（qfq/hfq/""），无需手动算因子。
+        """
+        try:
+            ak = _safe_akshare()
+        except ImportError as e:
+            _log.debug("akshare not installed: %s", e)
+            return []
+
+        today = date.today()
+        end_d = end or today
+        start_d = self._default_start(interval, end_d, limit) if start is None else start
+
+        adj_param = _ADJ_MAP.get(adjustment, "")
+        start_str = start_d.strftime("%Y%m%d")
+        end_str = end_d.strftime("%Y%m%d")
+
+        try:
+            if interval in _PERIOD_DWM:
+                df = ak.stock_zh_a_hist(
+                    symbol=code,
+                    period=_PERIOD_DWM[interval],
+                    start_date=start_str,
+                    end_date=end_str,
+                    adjust=adj_param,
+                )
+            elif interval in _PERIOD_MIN:
+                # 分钟接口的 start_date/end_date 是 "YYYY-MM-DD HH:MM:SS"
+                df = ak.stock_zh_a_hist_min_em(
+                    symbol=code,
+                    start_date=start_d.strftime("%Y-%m-%d 09:30:00"),
+                    end_date=end_d.strftime("%Y-%m-%d 15:00:00"),
+                    period=_PERIOD_MIN[interval],
+                    adjust=adj_param,
+                )
+            else:
+                return []
+        except Exception as e:
+            _log.debug("akshare get_bars(%s, %s) failed: %s", code, interval, e)
+            return []
+
+        if df is None or df.empty:
+            return []
+
+        bars: list[Bar] = []
+        for _, row in df.iterrows():
+            ts = self._parse_row_timestamp(row, interval)
+            if ts is None:
+                continue
+            # 二次过滤（合并时可能超出范围）
+            if start and ts.date() < start:
+                continue
+            if end and ts.date() > end:
+                continue
+
+            bars.append(
+                Bar(
+                    code=code,
+                    name="",  # stock_zh_a_hist 不带名称
+                    interval=interval,
+                    adjustment=adjustment,
+                    timestamp=ts,
+                    open=_to_dec(row.get("开盘")) or Decimal("0"),
+                    high=_to_dec(row.get("最高")) or Decimal("0"),
+                    low=_to_dec(row.get("最低")) or Decimal("0"),
+                    close=_to_dec(row.get("收盘")) or Decimal("0"),
+                    volume=_to_int(row.get("成交量")),
+                    turnover=_to_money(row.get("成交额")),
+                    change_pct=_to_dec(row.get("涨跌幅")),
+                    turnover_rate=_to_dec(row.get("换手率")),
+                    amplitude=_to_dec(row.get("振幅")),
+                )
+            )
+
+        bars.sort(key=lambda b: b.timestamp)
+        if limit is not None:
+            bars = bars[-limit:]
+        return bars
+
+    @staticmethod
+    def _default_start(
+        interval: BarInterval, end_d: date, limit: int | None
+    ) -> date:
+        """没指定 start 时，根据 interval + limit 推一个保守起点。"""
+        if interval == BarInterval.D1:
+            years = max(1, (limit or 500) // 250 + 1)
+            return end_d - timedelta(days=int(years * 366))
+        if interval == BarInterval.W1:
+            weeks = max(52, (limit or 200) + 4)
+            return end_d - timedelta(weeks=weeks)
+        if interval == BarInterval.M:
+            months = max(24, (limit or 60) + 2)
+            return end_d - timedelta(days=int(months * 31))
+        # 分钟线 akshare 只能返回近期
+        return end_d - timedelta(days=5)
+
+    @staticmethod
+    def _parse_row_timestamp(row: pd.Series, interval: BarInterval) -> datetime | None:
+        """从行里解析时间戳。日/周/月是 ``日期`` (YYYY-MM-DD)，分钟是 ``时间``。"""
+        raw = row.get("时间", "") if interval in _PERIOD_MIN else row.get("日期", "")
+        if raw is None or raw == "":
+            return None
+        try:
+            ts: datetime = pd.to_datetime(str(raw)).to_pydatetime()
+        except Exception:
+            return None
+        return ts
+
+    # ---------- Tick（第一步不实现）----------
+
+    def get_ticks(self, code: str, limit: int | None = None) -> list[Tick]:
+        """akshare 没有逐笔成交的稳定接口（只有分钟 bar），返回空。"""
+        return []
+
+    # ---------- 资金流 ----------
+
+    @staticmethod
+    def _fund_flow_market_suffix(code: str) -> str:
+        """``stock_individual_fund_flow`` 要 market 参数（sh/sz/bj）。
+
+        接口源码 market_map: sh=1, sz=0, bj=0。未知代码默认 sh（不会报错，
+        只是拿不到数据，调用方 try/except 兜住）。
+        """
+        m = _detect_market(code)
+        if m == MarketType.SZ:
+            return "sz"
+        if m == MarketType.BJ:
+            return "bj"
+        return "sh"
+
+    def _fetch_fund_flow_df(self, code: str) -> pd.DataFrame | None:
+        """拉个股资金流（近期，~100 天）。失败返回 None。
+
+        字段（来自 akshare 源码 stock_fund_em.py:52-68）：
+            日期(date) / 收盘价 / 涨跌幅 / 主力净流入-净额 / 主力净流入-净占比 /
+            超大单净流入-净额 / 超大单净流入-净占比 / 大单… / 中单… / 小单…
+        """
+        try:
+            ak = _safe_akshare()
+            df = ak.stock_individual_fund_flow(
+                stock=code, market=self._fund_flow_market_suffix(code)
+            )
+        except Exception as e:
+            _log.debug("akshare stock_individual_fund_flow(%s) failed: %s", code, e)
+            return None
+        if df is None or df.empty:
+            return None
+        return df
+
+    def _fund_flow_df_to_flows(self, df: pd.DataFrame, code: str) -> list[MoneyFlow]:
+        """fund_flow DataFrame → list[MoneyFlow]。"""
+        flows: list[MoneyFlow] = []
+        for _, row in df.iterrows():
+            # 日期列 akshare 已经 to_datetime().dt.date 过，是 date 对象
+            d_raw = row.get("日期")
+            if isinstance(d_raw, date) and not isinstance(d_raw, datetime):
+                ts = datetime.combine(d_raw, datetime.min.time())
+            else:
+                try:
+                    ts = pd.to_datetime(str(d_raw)).to_pydatetime()
+                except Exception:
+                    continue
+            flows.append(
+                MoneyFlow(
+                    code=code,
+                    name="",  # 接口不返回名称
+                    timestamp=ts,
+                    main_net=_to_money(row.get("主力净流入-净额")),
+                    small_net=_to_money(row.get("小单净流入-净额")),
+                    medium_net=_to_money(row.get("中单净流入-净额")),
+                    large_net=_to_money(row.get("大单净流入-净额")),
+                    super_large_net=_to_money(row.get("超大单净流入-净额")),
+                    main_net_ratio=_to_dec(row.get("主力净流入-净占比")),
+                )
+            )
+        return flows
+
+    def get_today_money_flow(self, code: str) -> list[MoneyFlow]:
+        """当日资金流：取接口返回的最新一行（盘后更新）。"""
+        df = self._fetch_fund_flow_df(code)
+        if df is None:
+            return []
+        try:
+            latest = df.iloc[0:1]  # akshare 默认降序，最新在前
+        except Exception:
+            return []
+        return self._fund_flow_df_to_flows(latest, code)
+
+    def get_history_money_flow(self, code: str, days: int = 30) -> list[MoneyFlow]:
+        """历史资金流：akshare 一次给 ~100 天，客户端按 days 截断。"""
+        df = self._fetch_fund_flow_df(code)
+        if df is None:
+            return []
+        flows = self._fund_flow_df_to_flows(df, code)
+        cutoff = datetime.now() - timedelta(days=days)
+        return [f for f in flows if f.timestamp >= cutoff]
+
+    # ---------- 板块 ----------
+
+    def get_belonging_boards(self, code: str) -> list[Board]:
+        """返回空，留给 efinance。
+
+        akshare 没有"单股 → 所属板块"的直接接口，只能遍历所有板块成分股反查
+        （~200 次 HTTP），太重。efinance.get_belong_board 是单股直接接口（1 次
+        HTTP），已在 fallback 链里兜底，akshare 在这里没有增量价值。
+        """
+        return []
+
+    # ---------- 健康检查 ----------
+
+    def health_check(self) -> bool:
+        """拉一行 spot，能拿到就算 OK。"""
+        df = self._fetch_spot_df()
+        return df is not None

--- a/src/mommy_chaogu/market_data/builder.py
+++ b/src/mommy_chaogu/market_data/builder.py
@@ -5,13 +5,16 @@
 
 未来要加新数据源、调整顺序、改成完全不同的链，都改这一个文件。
 
-链顺序（详见 docs/ADR/akshare-integration）：
+链顺序（详见 docs/ADR/akshare-integration / docs/ADR/tushare-integration）：
 
 1. **EfinanceAdapter** (主源) — 实时 + K 线 + 资金流 + 板块，覆盖最全
 2. **TencentAdapter** (兜底 1) — 实时报价的真正异构兜底（东财挂腾讯不一定挂）
 3. **AkShareAdapter** (兜底 2) — 字段补全源；和 efinance 同走东财后端，
    但 ``stock_zh_a_spot_em`` 给 PE/PB/市值更稳，K 线是另一个实现路径
    （仅在 akshare 已安装时启用，避免把 100MB 依赖强加给所有人）
+4. **TushareAdapter** (兜底 3) — 海外 IP 友好（阿里云）的金融数据云，
+   K 线/资金流/财务三表/分红最强，实时报价是 EOD 合成
+   （仅在 ``TUSHARE_TOKEN`` 环境变量配置时启用；Tushare 是付费档数据源）
 """
 
 from __future__ import annotations
@@ -39,6 +42,19 @@ def _akshare_available() -> bool:
     return True
 
 
+def _tushare_available() -> tuple[bool, object]:
+    """Tushare 是否可用（token 配置且能初始化 pro_api）。
+
+    返回 ``(available, adapter)``：
+    - available=True 时 adapter 是可用的 TushareAdapter
+    - available=False 时 adapter 是占位的 TushareAdapter 实例（仅供判断）
+    """
+    from mommy_chaogu.market_data.tushare_adapter import TushareAdapter
+
+    adp = TushareAdapter()
+    return adp.is_available, adp
+
+
 def build_default_adapter(
     *,
     with_cache: bool = False,
@@ -50,25 +66,40 @@ def build_default_adapter(
     顺序：
 
     1. EfinanceAdapter（主源，实时/K 线/资金流/板块覆盖最全）
-    2. TencentAdapter（实时报价的异构兜底）
-    3. AkShareAdapter（字段补全 + 备用 K 线；仅 akshare 已安装时启用）
+    2. TushareAdapter（境外 IP / K 线 / 财务首选；仅 TUSHARE_TOKEN 配置时启用，
+       没 token 自动跳过）
+    3. TencentAdapter（实时报价的真异构兜底）
+    4. AkShareAdapter（字段补全 + 备用 K 线；仅 akshare 已安装时启用）
 
     ``with_cache=True`` 时套一层 CachedMarketDataAdapter。
     """
-    # TencentAdapter.get_bars 用 **kw，跟 Protocol 强类型签名不一致（运行时兼容），
-    # 与 flows/service.py 同样的处理：用 type: ignore 转一道。
+    # 链顺序：efinance → tushare → tencent → akshare
+    # - efinance 放最前：国内 IP 实时报价最快、覆盖最全
+    # - tushare 第二位：境外 IP / K 线 / 财务首选；没 token 时自动跳过
+    # - tencent 第三位：实时报价的真异构兜底（东财挂腾讯不一定挂）
+    # - akshare 最末：字段补全源，仅在 akshare 已安装时启用
+    # TencentAdapter.get_bars 用 **kw，跟 Protocol 强类型签名不一致（运行时兼容）。
     adapters: list[MarketDataAdapter] = [
         EfinanceAdapter(),
-        TencentAdapter(),  # type: ignore[list-item]
     ]
+
+    sources = ["efinance"]
+
+    tushare_ok, tushare_adp = _tushare_available()
+    if tushare_ok:
+        adapters.append(tushare_adp)  # type: ignore[list-item]
+        sources.append("tushare")
+
+    adapters.append(TencentAdapter())  # type: ignore[list-item]
+    sources.append("tencent")
 
     if _akshare_available():
         from mommy_chaogu.market_data.akshare_adapter import AkShareAdapter
 
-        adapters.append(AkShareAdapter())
-        _log.info("data sources: efinance + tencent + akshare")
-    else:
-        _log.info("data sources: efinance + tencent (akshare not installed)")
+        adapters.append(AkShareAdapter())  # type: ignore[list-item]
+        sources.append("akshare")
+
+    _log.info("data sources: %s", " + ".join(sources))
 
     chain = FallbackAdapter(adapters)
 

--- a/src/mommy_chaogu/market_data/builder.py
+++ b/src/mommy_chaogu/market_data/builder.py
@@ -5,16 +5,17 @@
 
 未来要加新数据源、调整顺序、改成完全不同的链，都改这一个文件。
 
-链顺序（详见 docs/ADR/akshare-integration / docs/ADR/tushare-integration）：
+链顺序（详见 docs/adr/0002-akshare-integration.md / docs/adr/0003-tushare-integration.md）：
 
 1. **EfinanceAdapter** (主源) — 实时 + K 线 + 资金流 + 板块，覆盖最全
 2. **TencentAdapter** (兜底 1) — 实时报价的真正异构兜底（东财挂腾讯不一定挂）
-3. **AkShareAdapter** (兜底 2) — 字段补全源；和 efinance 同走东财后端，
+3. **TushareAdapter** (兜底 2) — 海外 IP 友好（阿里云）的金融数据云，
+   K 线/资金流/财务三表/分红最强；实时报价是 EOD 合成快照（可能滞后 30 天），
+   所以排在腾讯之后，避免截胡真正的实时兜底
+   （仅在 ``TUSHARE_TOKEN`` 环境变量配置时启用；Tushare 是付费档数据源）
+4. **AkShareAdapter** (兜底 3) — 字段补全源；和 efinance 同走东财后端，
    但 ``stock_zh_a_spot_em`` 给 PE/PB/市值更稳，K 线是另一个实现路径
    （仅在 akshare 已安装时启用，避免把 100MB 依赖强加给所有人）
-4. **TushareAdapter** (兜底 3) — 海外 IP 友好（阿里云）的金融数据云，
-   K 线/资金流/财务三表/分红最强，实时报价是 EOD 合成
-   （仅在 ``TUSHARE_TOKEN`` 环境变量配置时启用；Tushare 是付费档数据源）
 """
 
 from __future__ import annotations
@@ -29,6 +30,7 @@ from mommy_chaogu.market_data.tencent_adapter import TencentAdapter
 
 if TYPE_CHECKING:
     from mommy_chaogu.cache import CacheConfig, CacheStore
+    from mommy_chaogu.market_data.tushare_adapter import TushareAdapter
 
 _log = logging.getLogger(__name__)
 
@@ -42,7 +44,7 @@ def _akshare_available() -> bool:
     return True
 
 
-def _tushare_available() -> tuple[bool, object]:
+def _tushare_available() -> tuple[bool, TushareAdapter]:
     """Tushare 是否可用（token 配置且能初始化 pro_api）。
 
     返回 ``(available, adapter)``：
@@ -66,37 +68,36 @@ def build_default_adapter(
     顺序：
 
     1. EfinanceAdapter（主源，实时/K 线/资金流/板块覆盖最全）
-    2. TushareAdapter（境外 IP / K 线 / 财务首选；仅 TUSHARE_TOKEN 配置时启用，
-       没 token 自动跳过）
-    3. TencentAdapter（实时报价的真异构兜底）
+    2. TencentAdapter（实时报价的真异构兜底）
+    3. TushareAdapter（境外 IP / K 线 / 财务首选；仅 TUSHARE_TOKEN 配置时启用，
+       没 token 自动跳过。其 get_quote 是 EOD 合成快照，故排在腾讯之后）
     4. AkShareAdapter（字段补全 + 备用 K 线；仅 akshare 已安装时启用）
 
     ``with_cache=True`` 时套一层 CachedMarketDataAdapter。
     """
-    # 链顺序：efinance → tushare → tencent → akshare
+    # 链顺序：efinance → tencent → tushare → akshare
     # - efinance 放最前：国内 IP 实时报价最快、覆盖最全
-    # - tushare 第二位：境外 IP / K 线 / 财务首选；没 token 时自动跳过
-    # - tencent 第三位：实时报价的真异构兜底（东财挂腾讯不一定挂）
+    # - tencent 第二位：实时报价的真异构兜底（东财挂腾讯不一定挂）
+    # - tushare 第三位：境外 IP / K 线 / 财务首选；没 token 时自动跳过；
+    #   其 get_quote 是 EOD 快照（可能滞后），不能截胡腾讯的实时兜底
     # - akshare 最末：字段补全源，仅在 akshare 已安装时启用
     # TencentAdapter.get_bars 用 **kw，跟 Protocol 强类型签名不一致（运行时兼容）。
     adapters: list[MarketDataAdapter] = [
         EfinanceAdapter(),
+        TencentAdapter(),  # type: ignore[list-item]
     ]
 
-    sources = ["efinance"]
+    sources = ["efinance", "tencent"]
 
     tushare_ok, tushare_adp = _tushare_available()
     if tushare_ok:
-        adapters.append(tushare_adp)  # type: ignore[list-item]
+        adapters.append(tushare_adp)
         sources.append("tushare")
-
-    adapters.append(TencentAdapter())  # type: ignore[list-item]
-    sources.append("tencent")
 
     if _akshare_available():
         from mommy_chaogu.market_data.akshare_adapter import AkShareAdapter
 
-        adapters.append(AkShareAdapter())  # type: ignore[list-item]
+        adapters.append(AkShareAdapter())
         sources.append("akshare")
 
     _log.info("data sources: %s", " + ".join(sources))

--- a/src/mommy_chaogu/market_data/builder.py
+++ b/src/mommy_chaogu/market_data/builder.py
@@ -1,0 +1,84 @@
+"""数据源工厂：统一构建 fallback 链。
+
+业务层不要直接 ``FallbackAdapter([EfinanceAdapter(), TencentAdapter()])``，
+而是调 ``build_default_adapter()``，由这里决定加什么源、顺序怎么排。
+
+未来要加新数据源、调整顺序、改成完全不同的链，都改这一个文件。
+
+链顺序（详见 docs/ADR/akshare-integration）：
+
+1. **EfinanceAdapter** (主源) — 实时 + K 线 + 资金流 + 板块，覆盖最全
+2. **TencentAdapter** (兜底 1) — 实时报价的真正异构兜底（东财挂腾讯不一定挂）
+3. **AkShareAdapter** (兜底 2) — 字段补全源；和 efinance 同走东财后端，
+   但 ``stock_zh_a_spot_em`` 给 PE/PB/市值更稳，K 线是另一个实现路径
+   （仅在 akshare 已安装时启用，避免把 100MB 依赖强加给所有人）
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from mommy_chaogu.market_data.adapter import MarketDataAdapter
+from mommy_chaogu.market_data.efinance_adapter import EfinanceAdapter
+from mommy_chaogu.market_data.fallback_adapter import FallbackAdapter
+from mommy_chaogu.market_data.tencent_adapter import TencentAdapter
+
+if TYPE_CHECKING:
+    from mommy_chaogu.cache import CacheConfig, CacheStore
+
+_log = logging.getLogger(__name__)
+
+
+def _akshare_available() -> bool:
+    """akshare 是否已安装（避免 import 时把 100MB 依赖强加载给所有人）。"""
+    try:
+        import akshare  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def build_default_adapter(
+    *,
+    with_cache: bool = False,
+    cache_store: CacheStore | None = None,
+    cache_config: CacheConfig | None = None,
+) -> MarketDataAdapter:
+    """构造默认的多源 fallback 适配器。
+
+    顺序：
+
+    1. EfinanceAdapter（主源，实时/K 线/资金流/板块覆盖最全）
+    2. TencentAdapter（实时报价的异构兜底）
+    3. AkShareAdapter（字段补全 + 备用 K 线；仅 akshare 已安装时启用）
+
+    ``with_cache=True`` 时套一层 CachedMarketDataAdapter。
+    """
+    # TencentAdapter.get_bars 用 **kw，跟 Protocol 强类型签名不一致（运行时兼容），
+    # 与 flows/service.py 同样的处理：用 type: ignore 转一道。
+    adapters: list[MarketDataAdapter] = [
+        EfinanceAdapter(),
+        TencentAdapter(),  # type: ignore[list-item]
+    ]
+
+    if _akshare_available():
+        from mommy_chaogu.market_data.akshare_adapter import AkShareAdapter
+
+        adapters.append(AkShareAdapter())
+        _log.info("data sources: efinance + tencent + akshare")
+    else:
+        _log.info("data sources: efinance + tencent (akshare not installed)")
+
+    chain = FallbackAdapter(adapters)
+
+    if with_cache:
+        # 延迟 import 避免循环依赖
+        from mommy_chaogu.cache import CacheStore
+        from mommy_chaogu.cache.adapter import CachedMarketDataAdapter
+        from mommy_chaogu.db_paths import MARKET_DB
+
+        store = cache_store or CacheStore(MARKET_DB)
+        return CachedMarketDataAdapter(chain, store, config=cache_config)  # type: ignore[arg-type]
+
+    return chain  # type: ignore[return-value]

--- a/src/mommy_chaogu/market_data/efinance_adapter.py
+++ b/src/mommy_chaogu/market_data/efinance_adapter.py
@@ -65,18 +65,14 @@ def _to_money(v: Any) -> Money:
 
 
 def _detect_market(code: str) -> MarketType:
-    """根据股票代码头推断市场。"""
-    if code.startswith(("60", "68", "9")):  # 60xxx沪A主板, 688科创板, 9xx北交所
-        if code.startswith("9"):
-            return MarketType.BJ
-        return MarketType.SH
-    if code.startswith(("00", "30")):  # 00/30 深A
-        return MarketType.SZ
-    if code.startswith(("51", "15", "16", "18")):  # 场内基金/债券
-        return MarketType.SH
-    if code.startswith(("11", "12", "13", "14")):  # 深A基金/债券
-        return MarketType.SZ
-    return MarketType.UNKNOWN
+    """根据股票代码头推断市场。
+
+    委托给 ``market_data.utils.detect_market``，避免 efinance/tushare 两边各写一份
+    且各有遗漏（之前漏了 83/87/88/92/40-43 北交所/新三板）。
+    """
+    from mommy_chaogu.market_data.utils import detect_market
+
+    return detect_market(code)
 
 
 def _detect_quote_type(code: str) -> QuoteType:

--- a/src/mommy_chaogu/market_data/tushare_adapter.py
+++ b/src/mommy_chaogu/market_data/tushare_adapter.py
@@ -1,0 +1,861 @@
+"""Tushare 数据源实现（基于 tushare.pro API）。
+
+为什么用 Tushare 作为补充数据源：
+- 财务数据/历史 K 线/资金流/分红送股 — **业内最全最准**
+- 云服务（阿里云），**海外 IP 直连稳定**，对境外用户友好
+- 接口稳定，文档详细，字段命名规范
+- 适合作为 K 线/财务/资金流场景的**主源**，实时报价仍由东财/腾讯负责
+
+Tushare 的特点（与 efinance/腾讯区别）：
+- **EOD 数据为主**（盘后），不是实时行情
+- 代码格式：`600519.SH`（带 . 和后缀），与项目内部 `600519` 不同，需要转换
+- 需要 token（环境变量 `TUSHARE_TOKEN`），未配置时所有方法返回 None
+- 每次调用消耗积分，免费档每日 5000 次，中级档不限次
+- 走 HTTPS JSON API，不依赖任何爬虫
+
+使用：
+    adapter = TushareAdapter()  # 自动从环境变量 TUSHARE_TOKEN 读 token
+    quote = adapter.get_quote("600519")  # 返回 None（Tushare 不提供实时）
+    bars = adapter.get_bars("600519")    # 返回日 K 线（最准的源）
+    flows = adapter.get_history_money_flow("600519", days=30)  # 历史资金流
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import warnings
+from datetime import date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import pandas as pd
+
+from mommy_chaogu.market_data.types import (
+    AdjustmentType,
+    Bar,
+    BarInterval,
+    Board,
+    MarketType,
+    Money,
+    MoneyFlow,
+    OrderBook,
+    Quote,
+    QuoteType,
+    Tick,
+)
+
+warnings.filterwarnings("ignore")
+
+_log = logging.getLogger(__name__)
+
+
+# ---------- 内部工具 ----------
+
+
+def _to_dec(v: Any) -> Decimal | None:
+    """安全转 Decimal，失败返回 None。"""
+    if v is None:
+        return None
+    if isinstance(v, float) and pd.isna(v):
+        return None
+    try:
+        return Decimal(str(v))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _to_int(v: Any) -> int:
+    """安全转 int。"""
+    if v is None or (isinstance(v, float) and pd.isna(v)):
+        return 0
+    try:
+        return int(float(v))
+    except (ValueError, TypeError):
+        return 0
+
+
+def _to_money(v: Any) -> Money:
+    """转 Money（默认 CNY）。"""
+    amt = _to_dec(v) or Decimal("0")
+    return Money(amt, "CNY")
+
+
+# Tushare 市场后缀 → 项目 MarketType
+_TS_EXCHANGE_MAP: dict[str, MarketType] = {
+    "SH": MarketType.SH,
+    "SZ": MarketType.SZ,
+    "BJ": MarketType.BJ,
+}
+
+# MarketType → Tushare 后缀
+_MARKET_TO_TS_SUFFIX: dict[MarketType, str] = {
+    MarketType.SH: "SH",
+    MarketType.SZ: "SZ",
+    MarketType.BJ: "BJ",
+}
+
+
+def _detect_market_from_code(code: str) -> MarketType:
+    """根据 6 位股票代码头推断市场。已抽取到 market_data.utils.detect_market 统一维护。"""
+    from mommy_chaogu.market_data.utils import detect_market
+
+    return detect_market(code)
+
+
+def _detect_quote_type(code: str) -> QuoteType:
+    if code.startswith(("51", "15", "16", "18", "11", "12", "13", "14")):
+        return QuoteType.FUND
+    return QuoteType.STOCK
+
+
+def to_tushare_code(code: str, market: MarketType | None = None) -> str:
+    """项目内部代码 `600519` → Tushare 格式 `600519.SH`。
+
+    如果已包含 `.XX` 后缀则原样返回。
+    """
+    if "." in code:
+        return code
+    if market is None:
+        market = _detect_market_from_code(code)
+    suffix = _MARKET_TO_TS_SUFFIX.get(market, "SH")
+    return f"{code}.{suffix}"
+
+
+def from_tushare_code(ts_code: str) -> tuple[str, MarketType]:
+    """Tushare 格式 `600519.SH` → (项目内部代码 `600519`, 市场)。"""
+    if "." in ts_code:
+        code, suffix = ts_code.split(".", 1)
+        market = _TS_EXCHANGE_MAP.get(suffix.upper(), _detect_market_from_code(code))
+    else:
+        code = ts_code
+        market = _detect_market_from_code(code)
+    return code, market
+
+
+# ---------- 复权工具函数 ----------
+
+
+def apply_adjustment(
+    bars: list[Bar],
+    adj_factors: pd.DataFrame,
+    mode: AdjustmentType = AdjustmentType.FORWARD,
+) -> list[Bar]:
+    """对 K 线列表应用前/后复权。
+
+    输入：未复权 K 线 + 复权因子表（Tushare adj_factor 接口返回的格式）
+    输出：调整后的 K 线（新 Bar 实例，原列表不被修改）
+
+    参数:
+        bars: 待调整的 K 线列表（不复权原始价）
+        adj_factors: 复权因子表，必须包含两列：
+            - trade_date (str YYYYMMDD 或 datetime.date)
+            - adj_factor (float / Decimal)
+        mode: AdjustmentType.FORWARD（前复权）或 BACKWARD（后复权）
+
+    算法:
+        前复权 adj_price = raw_price * (latest_factor / current_factor)
+            → 调整后**最新价 = 原始最新价**（价格历史保持连续，历史价更低）
+            → 回测看历史业绩最常用
+        后复权 adj_price = raw_price * (earliest_factor / current_factor)
+            → 调整后**最早价 = 原始最早价**（最新价更高）
+            → 看完整历史涨幅用
+
+    使用场景:
+        - **实盘/盘中数据：不需要调用**（实时价就是实际价）
+        - **回测/历史可视化**：调用前复权，价格连续，复利计算正确
+        - **对比长期涨幅**：调用后复权，能看到从 IPO 起的真实回报
+
+    示例:
+        from tushare import pro_api
+        from mommy_chaogu.market_data.tushare_adapter import apply_adjustment
+        from mommy_chaogu.market_data.types import AdjustmentType
+
+        pro = pro_api('token')
+        # 1. 拉不复权 K 线
+        bars = adapter.get_bars("600519", AdjustmentType.NONE)
+        # 2. 拉复权因子
+        factors = pro.adj_factor(ts_code="600519.SH", start_date="20200101", end_date="20241231")
+        # 3. 应用前复权
+        bars_adj = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+    """
+    if mode == AdjustmentType.NONE or not bars:
+        return bars
+    if adj_factors is None or adj_factors.empty:
+        return bars
+
+    # 构造 {date_str: factor} 查找表
+    factor_map: dict[str, Decimal] = {}
+    for _, row in adj_factors.iterrows():
+        trade_date = row.get("trade_date")
+        if trade_date is None:
+            continue
+        # trade_date 可能是 str / Timestamp / date，统一转 YYYYMMDD
+        if isinstance(trade_date, str):
+            date_str = trade_date.replace("-", "")[:8]
+        else:
+            try:
+                date_str = pd.Timestamp(trade_date).strftime("%Y%m%d")
+            except (ValueError, TypeError):
+                continue
+        factor_val = _to_dec(row.get("adj_factor"))
+        if factor_val is not None and factor_val > 0:
+            factor_map[date_str] = factor_val
+
+    if not factor_map:
+        return bars
+
+    # 找基准因子：来自 bars 列表中最早/最晚一根 bar 的日期对应的因子
+    # Tushare 的 adj_factor 约定是"越早越大、越晚越小"（除权除息让因子下降），
+    # 所以不能用 max/min，要按日期取。
+    sorted_bars = sorted(bars, key=lambda b: b.timestamp)
+    latest_bar_date_str = sorted_bars[-1].timestamp.strftime("%Y%m%d")
+    earliest_bar_date_str = sorted_bars[0].timestamp.strftime("%Y%m%d")
+
+    if mode == AdjustmentType.FORWARD:
+        # 前复权：基准 = bars 中最新一根的因子（让最新价不变）
+        latest_factor = factor_map.get(latest_bar_date_str)
+        if latest_factor is None or latest_factor == 0:
+            return bars
+    else:  # BACKWARD
+        # 后复权：基准 = bars 中最早一根的因子（让最早价不变）
+        earliest_factor = factor_map.get(earliest_bar_date_str)
+        if earliest_factor is None or earliest_factor == 0:
+            return bars
+
+    adjusted: list[Bar] = []
+    for bar in bars:
+        # 提取 bar 的日期 key
+        bar_date_str = bar.timestamp.strftime("%Y%m%d")
+        cur_factor = factor_map.get(bar_date_str)
+        if cur_factor is None or cur_factor == 0:
+            # 找不到因子（可能日期超出范围或没数据），跳过调整
+            adjusted.append(bar)
+            continue
+
+        # 计算复权系数
+        if mode == AdjustmentType.FORWARD:
+            ratio = latest_factor / cur_factor  # type: ignore[operator]
+        else:
+            ratio = earliest_factor / cur_factor  # type: ignore[operator]
+
+        # 应用到 OHLC（不复权价 * ratio = 复权价）
+        new_open = (bar.open * ratio) if bar.open else bar.open
+        new_high = (bar.high * ratio) if bar.high else bar.high
+        new_low = (bar.low * ratio) if bar.low else bar.low
+        new_close = (bar.close * ratio) if bar.close else bar.close
+        # 注意：成交量和成交额不复权（除权除息不影响量）
+        # turnover_rate / change_pct / amplitude 不复权（已是相对值）
+
+        adjusted.append(
+            Bar(
+                code=bar.code,
+                name=bar.name,
+                interval=bar.interval,
+                adjustment=mode,
+                timestamp=bar.timestamp,
+                open=new_open,
+                high=new_high,
+                low=new_low,
+                close=new_close,
+                volume=bar.volume,
+                turnover=bar.turnover,
+                change_pct=bar.change_pct,
+                turnover_rate=bar.turnover_rate,
+                amplitude=bar.amplitude,
+            )
+        )
+
+    return adjusted
+
+
+# K 线周期 → Tushare freq 参数
+_FREQ_MAP: dict[BarInterval, str] = {
+    BarInterval.M1: "1min",
+    BarInterval.M5: "5min",
+    BarInterval.M15: "15min",
+    BarInterval.M30: "30min",
+    BarInterval.M60: "60min",
+    BarInterval.D1: "D",
+    BarInterval.W1: "W",
+    BarInterval.M: "M",
+}
+
+# 复权方式 → Tushare adj 参数（qfq/hfq/none）
+_ADJ_MAP: dict[AdjustmentType, str] = {
+    AdjustmentType.NONE: "none",
+    AdjustmentType.FORWARD: "qfq",
+    AdjustmentType.BACKWARD: "hfq",
+}
+
+
+# ---------- Adapter 实现 ----------
+
+
+class TushareAdapter:
+    """基于 Tushare Pro 的行情数据源。
+
+    优势场景：K 线、财务、资金流、分红。
+    弱势场景：实时报价（返回 None）、盘口（返回 None）— 这些由 efinance/腾讯兜底。
+    """
+
+    name = "tushare"
+
+    def __init__(self, token: str | None = None) -> None:
+        """token 默认从 TUSHARE_TOKEN 环境变量读；为空则所有方法返回 None。"""
+        self._token = token or os.environ.get("TUSHARE_TOKEN", "")
+        self._pro: Any = None
+        if self._token:
+            try:
+                import tushare as ts
+
+                ts.set_token(self._token)
+                self._pro = ts.pro_api()
+            except Exception as e:
+                _log.warning("Tushare 初始化失败: %s", e)
+                self._pro = None
+
+    @property
+    def is_available(self) -> bool:
+        return self._pro is not None
+
+    # ---------- 实时报价（Tushare 不提供，返回 None）----------
+
+    def get_quote(self, code: str) -> Quote | None:
+        """Tushare 是 EOD 数据，没有实时报价。
+
+        但我们可以从 daily_basic 拼一个"最新可用"的快照（带 PE/PB/换手率等指标）。
+        """
+        if not self.is_available:
+            return None
+        try:
+            ts_code = to_tushare_code(code)
+            today = date.today().strftime("%Y%m%d")
+            # 拿最近一个交易日的数据（往前查 30 天保证能命中）
+            start = (date.today() - timedelta(days=30)).strftime("%Y%m%d")
+            df = self._pro.daily_basic(
+                ts_code=ts_code, start_date=start, end_date=today, limit=1
+            )
+            if df is None or df.empty:
+                return None
+            row = df.iloc[0]
+
+            # 顺便拿一天 K 线补 open/high/low/close
+            daily_df = self._pro.daily(
+                ts_code=ts_code, start_date=start, end_date=today
+            )
+            if daily_df is None or daily_df.empty:
+                return None
+            daily_row = daily_df.iloc[0]
+
+            return Quote(
+                code=code,
+                name="",  # Tushare 跨接口 join 比较重，这里先留空
+                market=_detect_market_from_code(code),
+                quote_type=_detect_quote_type(code),
+                price=_to_dec(daily_row.get("close")) or Decimal("0"),
+                open=_to_dec(daily_row.get("open")) or Decimal("0"),
+                high=_to_dec(daily_row.get("high")) or Decimal("0"),
+                low=_to_dec(daily_row.get("low")) or Decimal("0"),
+                prev_close=_to_dec(daily_row.get("pre_close")) or Decimal("0"),
+                change=_to_dec(daily_row.get("change")) or Decimal("0"),
+                change_pct=_to_dec(daily_row.get("pct_chg")) or Decimal("0"),
+                volume=_to_int(daily_row.get("vol")),
+                turnover=_to_money(daily_row.get("amount")),
+                turnover_rate=_to_dec(row.get("turnover_rate")),
+                volume_ratio=None,
+                pe_dynamic=_to_dec(row.get("pe")),
+                # Tushare 市值单位是万元，需要 ×10000 转元
+                # 先转 Decimal 再构造 Money（Money 不能直接 * Decimal）
+                total_market_cap=(
+                    Money((_to_dec(row.get("total_mv")) or Decimal("0")) * Decimal("10000"), "CNY")
+                    if row.get("total_mv") is not None
+                    else None
+                ),
+                circulating_market_cap=(
+                    Money((_to_dec(row.get("circ_mv")) or Decimal("0")) * Decimal("10000"), "CNY")
+                    if row.get("circ_mv") is not None
+                    else None
+                ),
+                timestamp=datetime.now(),
+                extra={"source": "tushare_eod", "trade_date": str(daily_row.get("trade_date", ""))},
+            )
+        except Exception as e:
+            _log.debug("Tushare get_quote(%s) failed: %s", code, e)
+            return None
+
+    def get_quotes(self, codes: list[str]) -> list[Quote]:
+        """批量：循环单股。失败跳过。"""
+        out: list[Quote] = []
+        seen: set[str] = set()
+        for code in dict.fromkeys(codes):
+            if code in seen:
+                continue
+            q = self.get_quote(code)
+            if q is not None:
+                out.append(q)
+                seen.add(code)
+        return out
+
+    def list_market_quotes(self) -> list[Quote]:
+        """全市场快照：Tushare 不适合（要拉几千次 daily_basic），返回空。
+
+        这个场景用 efinance.list_market_quotes() 更合适。
+        """
+        return []
+
+    # ---------- 盘口（Tushare 不提供）----------
+
+    def get_order_book(self, code: str) -> OrderBook | None:
+        return None
+
+    # ---------- K 线（Tushare 强项）----------
+
+    def get_bars(
+        self,
+        code: str,
+        interval: BarInterval = BarInterval.D1,
+        adjustment: AdjustmentType = AdjustmentType.FORWARD,
+        start: date | None = None,
+        end: date | None = None,
+        limit: int | None = None,
+    ) -> list[Bar]:
+        """拉 K 线，支持前/后/不复权。
+
+        实现：
+        - 用 `tushare.pro_bar()` 顶层函数（内部会调 daily/weekly/monthly/stk_mins + adj_factor）
+        - `adj='qfq'` 前复权 / `adj='hfq'` 后复权 / `adj=None` 不复权
+        - 分钟线 Tushare 只支持最近 5 个交易日
+
+        复权说明：
+        - Tushare 的 `daily` 接口返回**不复权**原始价
+        - `adj_factor` 是单独的复权因子接口
+        - `pro_bar` 自动合并二者并计算复权价
+        """
+        if not self.is_available:
+            return []
+
+        ts_code = to_tushare_code(code)
+        freq = _FREQ_MAP.get(interval)
+        if freq is None:
+            return []
+
+        today = date.today()
+        end_d = end or today
+        if start is None:
+            # 没指定 start 时根据 limit 推一个保守起点
+            if interval == BarInterval.D1:
+                years = max(1, (limit or 500) // 250 + 1)
+                start_d = end_d - timedelta(days=int(years * 366))
+            elif interval == BarInterval.W1:
+                weeks = max(52, (limit or 200) + 4)
+                start_d = end_d - timedelta(weeks=weeks)
+            elif interval == BarInterval.M:
+                months = max(24, (limit or 60) + 2)
+                start_d = end_d - timedelta(days=int(months * 31))
+            else:
+                # 分钟线 Tushare 只支持最近 5 个交易日
+                start_d = end_d - timedelta(days=5)
+        else:
+            start_d = start
+
+        start_str = start_d.strftime("%Y%m%d")
+        end_str = end_d.strftime("%Y%m%d")
+
+        # 复权参数：None/qfq/hfq
+        adj_param: str | None
+        if adjustment == AdjustmentType.FORWARD:
+            adj_param = "qfq"
+        elif adjustment == AdjustmentType.BACKWARD:
+            adj_param = "hfq"
+        else:
+            adj_param = None
+
+        try:
+            # 延迟 import pro_bar（避免冷启动慢）
+            from tushare.pro.data_pro import pro_bar
+
+            df = pro_bar(
+                ts_code=ts_code,
+                api=self._pro,
+                start_date=start_str,
+                end_date=end_str,
+                freq=freq,
+                asset="E",  # 股票
+                adj=adj_param,
+                factors=["tor"],  # 顺便拿换手率（turnover_rate）
+            )
+            if df is None or df.empty:
+                return []
+        except Exception as e:
+            _log.debug("Tushare get_bars(%s, %s) failed: %s", code, interval, e)
+            return []
+
+        bars: list[Bar] = []
+        for _, row in df.iterrows():
+            trade_date = str(row.get("trade_date", ""))
+            if not trade_date:
+                continue
+            try:
+                ts = datetime.strptime(trade_date, "%Y%m%d")
+            except ValueError:
+                continue
+            # 二次过滤（合并时可能超出范围）
+            if start and ts.date() < start:
+                continue
+            if end and ts.date() > end:
+                continue
+
+            bars.append(
+                Bar(
+                    code=code,
+                    name="",  # daily 接口不带 name，需要时再 join
+                    interval=interval,
+                    adjustment=adjustment,
+                    timestamp=ts,
+                    open=_to_dec(row.get("open")) or Decimal("0"),
+                    high=_to_dec(row.get("high")) or Decimal("0"),
+                    low=_to_dec(row.get("low")) or Decimal("0"),
+                    close=_to_dec(row.get("close")) or Decimal("0"),
+                    volume=_to_int(row.get("vol")),
+                    turnover=_to_money(row.get("amount")),
+                    change_pct=_to_dec(row.get("pct_chg")),
+                    turnover_rate=None,  # daily 接口不返回
+                    amplitude=None,
+                )
+            )
+
+        bars.sort(key=lambda b: b.timestamp)
+        if limit is not None:
+            bars = bars[-limit:]
+        return bars
+
+    # ---------- Tick（Tushare 不提供分钟级逐笔）----------
+
+    def get_ticks(self, code: str, limit: int | None = None) -> list[Tick]:
+        return []
+
+    # ---------- 资金流 ----------
+
+    def _bill_df_to_flow(self, df: pd.DataFrame, code: str) -> list[MoneyFlow]:
+        if df is None or df.empty:
+            return []
+        flows: list[MoneyFlow] = []
+        for _, row in df.iterrows():
+            trade_date = str(row.get("trade_date", ""))
+            if not trade_date:
+                continue
+            try:
+                ts = datetime.strptime(trade_date, "%Y%m%d")
+            except ValueError:
+                continue
+            flows.append(
+                MoneyFlow(
+                    code=code,
+                    name="",
+                    timestamp=ts,
+                    main_net=_to_money(row.get("net_mf_amount")),
+                    small_net=_to_money(row.get("net_xl_amount")),  # 小单
+                    medium_net=_to_money(row.get("net_l_amount")),  # 中单
+                    large_net=_to_money(row.get("net_el_amount")),  # 大单
+                    super_large_net=_to_money(row.get("net_vl_amount")),  # 超大单
+                    main_net_ratio=None,  # moneyflow 接口不直接给占比
+                )
+            )
+        return flows
+
+    def get_today_money_flow(self, code: str) -> list[MoneyFlow]:
+        """当日资金流：Tushare 是 EOD 一次给整天的，返回一个点。"""
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            today = date.today().strftime("%Y%m%d")
+            # Tushare 不能"只看今天"，要看是否有今天的数据
+            start = (date.today() - timedelta(days=7)).strftime("%Y%m%d")
+            df = self._pro.moneyflow(ts_code=ts_code, start_date=start, end_date=today)
+            if df is None or df.empty:
+                return []
+            # 取最新一条
+            latest = df.iloc[0]
+            trade_date = str(latest.get("trade_date", ""))
+            if trade_date != today:
+                # 当天数据可能还没出（盘后才更新），返回最近一天的
+                pass
+            return self._bill_df_to_flow(df.head(1), code)
+        except Exception as e:
+            _log.debug("Tushare get_today_money_flow(%s) failed: %s", code, e)
+            return []
+
+    def get_history_money_flow(self, code: str, days: int = 30) -> list[MoneyFlow]:
+        """历史资金流：默认 30 天。"""
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            end = date.today()
+            start = end - timedelta(days=days + 5)  # 多取几天避开节假日
+            df = self._pro.moneyflow(
+                ts_code=ts_code,
+                start_date=start.strftime("%Y%m%d"),
+                end_date=end.strftime("%Y%m%d"),
+            )
+            flows = self._bill_df_to_flow(df, code)
+            cutoff = datetime.now() - timedelta(days=days)
+            return [f for f in flows if f.timestamp >= cutoff]
+        except Exception as e:
+            _log.debug("Tushare get_history_money_flow(%s) failed: %s", code, e)
+            return []
+
+    # ---------- 复权便捷方法 ----------
+
+    def fetch_and_adjust(
+        self,
+        code: str,
+        interval: BarInterval = BarInterval.D1,
+        mode: AdjustmentType = AdjustmentType.FORWARD,
+        start: date | None = None,
+        end: date | None = None,
+        limit: int | None = None,
+    ) -> list[Bar]:
+        """一键拉取并复权：拉不复权 K 线 + 复权因子 + 应用前/后复权。
+
+        适用场景：
+        - 拉带复权的历史 K 线（pro_bar 在某些场景表现不如手动控制）
+        - 调试 / 验证复权计算是否正确
+        - 对**非 Tushare 数据源**（如 efinance）拉的不复权价应用复权
+
+        实盘/盘中场景不需要调这个方法。
+
+        实现：拉 `daily` 不复权 + 拉 `adj_factor` + 调 `apply_adjustment`。
+        """
+        if not self.is_available:
+            return []
+
+        # 1. 拉不复权 K 线
+        bars = self.get_bars(
+            code, interval, AdjustmentType.NONE, start=start, end=end, limit=limit
+        )
+        if not bars:
+            return []
+
+        # 2. 拉复权因子（用相同时间范围）
+        ts_code = to_tushare_code(code)
+        try:
+            first_date = bars[0].timestamp.strftime("%Y%m%d")
+            last_date = bars[-1].timestamp.strftime("%Y%m%d")
+            adj_df = self._pro.adj_factor(
+                ts_code=ts_code, start_date=first_date, end_date=last_date
+            )
+        except Exception as e:
+            _log.debug("fetch_and_adjust: adj_factor failed for %s: %s", code, e)
+            return bars  # 拿不到因子就返回原始
+
+        # 3. 应用复权
+        return apply_adjustment(bars, adj_df, mode)
+
+    # ---------- 板块 ----------
+
+    def get_belonging_boards(self, code: str) -> list[Board]:
+        """Tushare 概念板块：通过 stock_basic → concept 或者 index_classify。
+
+        用 index_classify 获取所有概念/行业指数列表，然后逐个查成分股。
+        为效率，这里只查"所属"信息（用 limit_list_d 的 ts_code 反查所属概念不直接支持，
+        退而求其次：用 concept 接口）。
+        """
+        if not self.is_available:
+            return []
+        # 留给 efinance.get_belong_board 兜底（Tushare concept 接口
+        # 需要先拉所有概念 + 逐个查成分股，集成较重，先不强求）
+        # 实测有日志需求时打开下面调试日志：
+        # _log.debug("Tushare get_belonging_boards(%s) skipped: use efinance fallback", code)
+        return []
+
+    # ---------- 健康检查 ----------
+
+    def health_check(self) -> bool:
+        """拉一次交易日历（最便宜的接口），能拿到数据就算 OK。"""
+        if not self.is_available:
+            return False
+        try:
+            today = date.today().strftime("%Y%m%d")
+            df = self._pro.trade_cal(exchange="SSE", start_date=today, end_date=today)
+            return df is not None and not df.empty
+        except Exception:
+            return False
+
+    # ---------- 财务数据（Tushare 强项）----------
+
+    def get_financial_indicator(
+        self,
+        code: str,
+        period: str | None = None,
+        limit: int = 8,
+    ) -> list[dict[str, Any]]:
+        """拉取财务指标（PE/PB/ROE/资产负债率/毛利/净利 等）。
+
+        参数:
+            code: 6 位股票代码 '600519'
+            period: 报告期 YYYYMMDD（如 '20240930' = 2024 Q3）；None = 最新期
+            limit: 返回期数（默认 8 个季度 = 2 年）
+
+        返回:
+            list[dict]，每个 dict 是一期的财务指标，键名与 Tushare 原始字段一致
+            （eps, roe, gross_profit_margin, debt_to_assets, current_ratio, ...）
+            返回 [] 表示无 token / 拉取失败 / 无数据
+
+        使用场景:
+            - 选股过滤（ROE > 15%, 负债率 < 50%）
+            - 回测/基本面分析
+            - 长期价值跟踪
+        """
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            kwargs: dict[str, Any] = {"ts_code": ts_code, "limit": limit}
+            if period:
+                kwargs["period"] = period
+            df = self._pro.fina_indicator(**kwargs)
+            if df is None or df.empty:
+                return []
+            return df.to_dict(orient="records")
+        except Exception as e:
+            _log.debug("Tushare get_financial_indicator(%s) failed: %s", code, e)
+            return []
+
+    def get_dividend_history(self, code: str, limit: int = 20) -> list[dict[str, Any]]:
+        """拉取分红送股记录。
+
+        参数:
+            code: 6 位股票代码
+            limit: 最多返回条数（默认 20 条）
+
+        返回:
+            list[dict]，字段：end_date, ann_date, div_proc, stk_div, stk_bo_rate,
+            stk_co_rate, cash_div, cash_div_tax, record_date, ex_date, pay_date, ...
+
+        使用场景:
+            - 查历史分红率
+            - 股息率计算
+            - 回测分红再投资策略
+        """
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            df = self._pro.dividend(ts_code=ts_code, limit=limit)
+            if df is None or df.empty:
+                return []
+            return df.to_dict(orient="records")
+        except Exception as e:
+            _log.debug("Tushare get_dividend_history(%s) failed: %s", code, e)
+            return []
+
+    def get_income_statement(
+        self,
+        code: str,
+        period: str | None = None,
+        limit: int = 4,
+    ) -> list[dict[str, Any]]:
+        """拉取利润表（季报）。
+
+        参数:
+            code: 6 位股票代码
+            period: 报告期 YYYYMMDD；None = 最新期
+            limit: 返回期数
+
+        返回:
+            list[dict]，字段：total_revenue（营收）, operate_income（营业利润）,
+            total_profit（利润总额）, n_income（净利润）, basic_eps（基本EPS）...
+        """
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            kwargs: dict[str, Any] = {"ts_code": ts_code, "limit": limit}
+            if period:
+                kwargs["period"] = period
+            df = self._pro.income(**kwargs)
+            if df is None or df.empty:
+                return []
+            return df.to_dict(orient="records")
+        except Exception as e:
+            _log.debug("Tushare get_income_statement(%s) failed: %s", code, e)
+            return []
+
+    def get_balance_sheet(
+        self,
+        code: str,
+        period: str | None = None,
+        limit: int = 4,
+    ) -> list[dict[str, Any]]:
+        """拉取资产负债表。
+
+        返回字段：total_assets, total_liab, total_equity, money_cap, accounts_receivable...
+        """
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            kwargs: dict[str, Any] = {"ts_code": ts_code, "limit": limit}
+            if period:
+                kwargs["period"] = period
+            df = self._pro.balancesheet(**kwargs)
+            if df is None or df.empty:
+                return []
+            return df.to_dict(orient="records")
+        except Exception as e:
+            _log.debug("Tushare get_balance_sheet(%s) failed: %s", code, e)
+            return []
+
+    def get_cash_flow(
+        self,
+        code: str,
+        period: str | None = None,
+        limit: int = 4,
+    ) -> list[dict[str, Any]]:
+        """拉取现金流量表。
+
+        返回字段：n_cashflow_act（经营现金流）, n_cashflow_inv_act（投资现金流）,
+        n_cashflow_fin_act（筹资现金流）, free_cashflow...
+        """
+        if not self.is_available:
+            return []
+        try:
+            ts_code = to_tushare_code(code)
+            kwargs: dict[str, Any] = {"ts_code": ts_code, "limit": limit}
+            if period:
+                kwargs["period"] = period
+            df = self._pro.cashflow(**kwargs)
+            if df is None or df.empty:
+                return []
+            return df.to_dict(orient="records")
+        except Exception as e:
+            _log.debug("Tushare get_cash_flow(%s) failed: %s", code, e)
+            return []
+
+    def list_all_stocks(self, list_status: str = "L") -> list[dict[str, Any]]:
+        """拉取全市场股票列表。
+
+        参数:
+            list_status: 'L' = 在市 / 'D' = 退市 / 'P' = 暂停上市
+
+        返回:
+            list[dict]，字段：ts_code, symbol, name, industry, list_date, ...
+
+        使用场景:
+            - 一次性缓存所有股票基本信息
+            - 按行业过滤
+            - 全市场扫描
+        """
+        if not self.is_available:
+            return []
+        try:
+            df = self._pro.stock_basic(list_status=list_status)
+            if df is None or df.empty:
+                return []
+            return df.to_dict(orient="records")
+        except Exception as e:
+            _log.debug("Tushare list_all_stocks failed: %s", e)
+            return []

--- a/src/mommy_chaogu/market_data/tushare_adapter.py
+++ b/src/mommy_chaogu/market_data/tushare_adapter.py
@@ -10,7 +10,12 @@ Tushare 的特点（与 efinance/腾讯区别）：
 - **EOD 数据为主**（盘后），不是实时行情
 - 代码格式：`600519.SH`（带 . 和后缀），与项目内部 `600519` 不同，需要转换
 - 需要 token（环境变量 `TUSHARE_TOKEN`），未配置时所有方法返回 None
-- 每次调用消耗积分，免费档每日 5000 次，中级档不限次
+- 积分门槛（见 https://tushare.pro/document/1?doc_id=13）：
+  daily 基础积分每分钟 500 次；**moneyflow / adj_factor 需 2000 积分起**；
+  stk_mins 分钟线需单独权限。积分不足时接口报错被静默降级为 None/[]，
+  用 health_check() 可探活，但积分等级需自行在 tushare.pro 后台确认
+- 分钟线**不支持**（stk_mins 日期格式/权限/列名均与日线路径不同，见 get_bars）
+- moneyflow 只覆盖**沪深** A 股（不含北交所）
 - 走 HTTPS JSON API，不依赖任何爬虫
 
 使用：
@@ -24,7 +29,6 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from datetime import date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -44,8 +48,6 @@ from mommy_chaogu.market_data.types import (
     QuoteType,
     Tick,
 )
-
-warnings.filterwarnings("ignore")
 
 _log = logging.getLogger(__name__)
 
@@ -75,9 +77,9 @@ def _to_int(v: Any) -> int:
         return 0
 
 
-def _to_money(v: Any) -> Money:
-    """转 Money（默认 CNY）。"""
-    amt = _to_dec(v) or Decimal("0")
+def _to_money_scaled(v: Any, scale: str) -> Money:
+    """转 Money 并乘以倍率（用于 Tushare 的非元单位：daily.amount=千元、moneyflow=万元）。"""
+    amt = (_to_dec(v) or Decimal("0")) * Decimal(scale)
     return Money(amt, "CNY")
 
 
@@ -104,8 +106,11 @@ def _detect_market_from_code(code: str) -> MarketType:
 
 
 def _detect_quote_type(code: str) -> QuoteType:
-    if code.startswith(("51", "15", "16", "18", "11", "12", "13", "14")):
+    # 51/56/15/16/18 为场内基金；10~14 为债券/可转债（11xxxx、12xxxx 是沪深可转债）
+    if code.startswith(("51", "56", "15", "16", "18")):
         return QuoteType.FUND
+    if code.startswith(("10", "11", "12", "13", "14")):
+        return QuoteType.BOND
     return QuoteType.STOCK
 
 
@@ -154,12 +159,15 @@ def apply_adjustment(
         mode: AdjustmentType.FORWARD（前复权）或 BACKWARD（后复权）
 
     算法:
-        前复权 adj_price = raw_price * (latest_factor / current_factor)
-            → 调整后**最新价 = 原始最新价**（价格历史保持连续，历史价更低）
-            → 回测看历史业绩最常用
-        后复权 adj_price = raw_price * (earliest_factor / current_factor)
+        前复权 adj_price = raw_price * (current_factor / latest_factor)
+            → 调整后**最新价 = 原始最新价**（历史价按因子比例压低，价格序列连续）
+            → 回测看历史业绩最常用；与 Tushare pro_bar(adj='qfq') 公式一致
+        后复权 adj_price = raw_price * (current_factor / earliest_factor)
             → 调整后**最早价 = 原始最早价**（最新价更高）
             → 看完整历史涨幅用
+
+        注意 Tushare adj_factor 的方向：上市首日 = 1，之后每次分红送股
+        **累乘增大**（如 000001.SZ 2018 年已 108.031），即越晚越大。
 
     使用场景:
         - **实盘/盘中数据：不需要调用**（实时价就是实际价）
@@ -206,8 +214,6 @@ def apply_adjustment(
         return bars
 
     # 找基准因子：来自 bars 列表中最早/最晚一根 bar 的日期对应的因子
-    # Tushare 的 adj_factor 约定是"越早越大、越晚越小"（除权除息让因子下降），
-    # 所以不能用 max/min，要按日期取。
     sorted_bars = sorted(bars, key=lambda b: b.timestamp)
     latest_bar_date_str = sorted_bars[-1].timestamp.strftime("%Y%m%d")
     earliest_bar_date_str = sorted_bars[0].timestamp.strftime("%Y%m%d")
@@ -233,11 +239,11 @@ def apply_adjustment(
             adjusted.append(bar)
             continue
 
-        # 计算复权系数
+        # 计算复权系数（Tushare 因子越晚越大：cur/latest ≤ 1 压低历史价 = 前复权）
         if mode == AdjustmentType.FORWARD:
-            ratio = latest_factor / cur_factor  # type: ignore[operator]
+            ratio = cur_factor / latest_factor  # type: ignore[operator]
         else:
-            ratio = earliest_factor / cur_factor  # type: ignore[operator]
+            ratio = cur_factor / earliest_factor  # type: ignore[operator]
 
         # 应用到 OHLC（不复权价 * ratio = 复权价）
         new_open = (bar.open * ratio) if bar.open else bar.open
@@ -270,12 +276,10 @@ def apply_adjustment(
 
 
 # K 线周期 → Tushare freq 参数
+# 分钟线（M1~M60）**故意不支持**：stk_mins 需单独积分权限、start/end 要
+# 'YYYY-MM-DD HH:MM:SS' 格式，且 pro_bar 在 adj≠None 时会 drop 掉 trade_date
+# 列只剩 trade_time —— 静默返回空不如直接拒绝。分钟线请走 efinance。
 _FREQ_MAP: dict[BarInterval, str] = {
-    BarInterval.M1: "1min",
-    BarInterval.M5: "5min",
-    BarInterval.M15: "15min",
-    BarInterval.M30: "30min",
-    BarInterval.M60: "60min",
     BarInterval.D1: "D",
     BarInterval.W1: "W",
     BarInterval.M: "M",
@@ -333,20 +337,20 @@ class TushareAdapter:
             today = date.today().strftime("%Y%m%d")
             # 拿最近一个交易日的数据（往前查 30 天保证能命中）
             start = (date.today() - timedelta(days=30)).strftime("%Y%m%d")
-            df = self._pro.daily_basic(
-                ts_code=ts_code, start_date=start, end_date=today, limit=1
-            )
+            df = self._pro.daily_basic(ts_code=ts_code, start_date=start, end_date=today)
             if df is None or df.empty:
                 return None
-            row = df.iloc[0]
+            row = df.iloc[0]  # daily_basic 按日期倒序，第一行是最新交易日
 
             # 顺便拿一天 K 线补 open/high/low/close
-            daily_df = self._pro.daily(
-                ts_code=ts_code, start_date=start, end_date=today
-            )
+            daily_df = self._pro.daily(ts_code=ts_code, start_date=start, end_date=today)
             if daily_df is None or daily_df.empty:
                 return None
             daily_row = daily_df.iloc[0]
+
+            # Tushare 市值单位是万元，需要 ×10000 转元；NaN 时给 None 而不是 Money(0)
+            total_mv = _to_dec(row.get("total_mv"))
+            circ_mv = _to_dec(row.get("circ_mv"))
 
             return Quote(
                 code=code,
@@ -361,21 +365,16 @@ class TushareAdapter:
                 change=_to_dec(daily_row.get("change")) or Decimal("0"),
                 change_pct=_to_dec(daily_row.get("pct_chg")) or Decimal("0"),
                 volume=_to_int(daily_row.get("vol")),
-                turnover=_to_money(daily_row.get("amount")),
+                # daily.amount 单位是**千元**（见 tushare.pro/document/2?doc_id=27）
+                turnover=_to_money_scaled(daily_row.get("amount"), "1000"),
                 turnover_rate=_to_dec(row.get("turnover_rate")),
                 volume_ratio=None,
                 pe_dynamic=_to_dec(row.get("pe")),
-                # Tushare 市值单位是万元，需要 ×10000 转元
-                # 先转 Decimal 再构造 Money（Money 不能直接 * Decimal）
                 total_market_cap=(
-                    Money((_to_dec(row.get("total_mv")) or Decimal("0")) * Decimal("10000"), "CNY")
-                    if row.get("total_mv") is not None
-                    else None
+                    Money(total_mv * Decimal("10000"), "CNY") if total_mv is not None else None
                 ),
                 circulating_market_cap=(
-                    Money((_to_dec(row.get("circ_mv")) or Decimal("0")) * Decimal("10000"), "CNY")
-                    if row.get("circ_mv") is not None
-                    else None
+                    Money(circ_mv * Decimal("10000"), "CNY") if circ_mv is not None else None
                 ),
                 timestamp=datetime.now(),
                 extra={"source": "tushare_eod", "trade_date": str(daily_row.get("trade_date", ""))},
@@ -385,16 +384,12 @@ class TushareAdapter:
             return None
 
     def get_quotes(self, codes: list[str]) -> list[Quote]:
-        """批量：循环单股。失败跳过。"""
+        """批量：循环单股（每股 2 次 API 调用，注意积分消耗）。失败跳过。"""
         out: list[Quote] = []
-        seen: set[str] = set()
         for code in dict.fromkeys(codes):
-            if code in seen:
-                continue
             q = self.get_quote(code)
             if q is not None:
                 out.append(q)
-                seen.add(code)
         return out
 
     def list_market_quotes(self) -> list[Quote]:
@@ -420,12 +415,13 @@ class TushareAdapter:
         end: date | None = None,
         limit: int | None = None,
     ) -> list[Bar]:
-        """拉 K 线，支持前/后/不复权。
+        """拉 K 线，支持前/后/不复权（仅日/周/月线，分钟线不支持直接返回 []）。
 
         实现：
-        - 用 `tushare.pro_bar()` 顶层函数（内部会调 daily/weekly/monthly/stk_mins + adj_factor）
+        - 用 `tushare.pro_bar()` 顶层函数（内部会调 daily/weekly/monthly + adj_factor）
         - `adj='qfq'` 前复权 / `adj='hfq'` 后复权 / `adj=None` 不复权
-        - 分钟线 Tushare 只支持最近 5 个交易日
+        - 分钟线（M1~M60）不支持：stk_mins 需单独积分权限，且 pro_bar 在
+          adj≠None 时会丢弃 trade_date 列，无法可靠解析 —— 请走 efinance
 
         复权说明：
         - Tushare 的 `daily` 接口返回**不复权**原始价
@@ -450,12 +446,9 @@ class TushareAdapter:
             elif interval == BarInterval.W1:
                 weeks = max(52, (limit or 200) + 4)
                 start_d = end_d - timedelta(weeks=weeks)
-            elif interval == BarInterval.M:
+            else:  # 月线
                 months = max(24, (limit or 60) + 2)
                 start_d = end_d - timedelta(days=int(months * 31))
-            else:
-                # 分钟线 Tushare 只支持最近 5 个交易日
-                start_d = end_d - timedelta(days=5)
         else:
             start_d = start
 
@@ -518,9 +511,11 @@ class TushareAdapter:
                     low=_to_dec(row.get("low")) or Decimal("0"),
                     close=_to_dec(row.get("close")) or Decimal("0"),
                     volume=_to_int(row.get("vol")),
-                    turnover=_to_money(row.get("amount")),
+                    # daily.amount 单位是**千元**（见 tushare.pro/document/2?doc_id=27）
+                    turnover=_to_money_scaled(row.get("amount"), "1000"),
                     change_pct=_to_dec(row.get("pct_chg")),
-                    turnover_rate=None,  # daily 接口不返回
+                    # factors=["tor"] 让 pro_bar 从 daily_basic 并入换手率（仅日线有）
+                    turnover_rate=_to_dec(row.get("turnover_rate")),
                     amplitude=None,
                 )
             )
@@ -538,8 +533,23 @@ class TushareAdapter:
     # ---------- 资金流 ----------
 
     def _bill_df_to_flow(self, df: pd.DataFrame, code: str) -> list[MoneyFlow]:
+        """moneyflow 接口 DataFrame → MoneyFlow 列表。
+
+        字段与单位（见 tushare.pro/document/2?doc_id=170）：
+        - 各档位只有 buy/sell 两组字段，净流入需自算：buy_xx_amount - sell_xx_amount
+        - 所有 amount 字段单位是**万元**，统一 ×10000 转元
+        - net_mf_amount 是 Tushare 官方算好的净流入额（基于 L2 主动买卖单，
+          不等于四档简单相加），映射为主力净流入
+        """
         if df is None or df.empty:
             return []
+
+        def _net_wan(row: pd.Series, prefix: str) -> Money:
+            """buy_{prefix}_amount - sell_{prefix}_amount（万元 → 元）。"""
+            buy = _to_dec(row.get(f"buy_{prefix}_amount")) or Decimal("0")
+            sell = _to_dec(row.get(f"sell_{prefix}_amount")) or Decimal("0")
+            return Money((buy - sell) * Decimal("10000"), "CNY")
+
         flows: list[MoneyFlow] = []
         for _, row in df.iterrows():
             trade_date = str(row.get("trade_date", ""))
@@ -554,41 +564,39 @@ class TushareAdapter:
                     code=code,
                     name="",
                     timestamp=ts,
-                    main_net=_to_money(row.get("net_mf_amount")),
-                    small_net=_to_money(row.get("net_xl_amount")),  # 小单
-                    medium_net=_to_money(row.get("net_l_amount")),  # 中单
-                    large_net=_to_money(row.get("net_el_amount")),  # 大单
-                    super_large_net=_to_money(row.get("net_vl_amount")),  # 超大单
+                    main_net=_to_money_scaled(row.get("net_mf_amount"), "10000"),
+                    small_net=_net_wan(row, "sm"),  # 小单
+                    medium_net=_net_wan(row, "md"),  # 中单
+                    large_net=_net_wan(row, "lg"),  # 大单
+                    super_large_net=_net_wan(row, "elg"),  # 特大单
                     main_net_ratio=None,  # moneyflow 接口不直接给占比
                 )
             )
         return flows
 
     def get_today_money_flow(self, code: str) -> list[MoneyFlow]:
-        """当日资金流：Tushare 是 EOD 一次给整天的，返回一个点。"""
+        """当日资金流：Tushare 是 EOD 一次给整天的，返回最近一个交易日一个点。
+
+        注意：moneyflow 接口需 2000 积分，且只覆盖沪深 A 股（北交所返回空）。
+        盘中调用时当天数据通常还没入库，返回的是**上一交易日**的数据。
+        """
         if not self.is_available:
             return []
         try:
             ts_code = to_tushare_code(code)
             today = date.today().strftime("%Y%m%d")
-            # Tushare 不能"只看今天"，要看是否有今天的数据
             start = (date.today() - timedelta(days=7)).strftime("%Y%m%d")
             df = self._pro.moneyflow(ts_code=ts_code, start_date=start, end_date=today)
             if df is None or df.empty:
                 return []
-            # 取最新一条
-            latest = df.iloc[0]
-            trade_date = str(latest.get("trade_date", ""))
-            if trade_date != today:
-                # 当天数据可能还没出（盘后才更新），返回最近一天的
-                pass
+            # 按日期倒序，第一条是最新交易日
             return self._bill_df_to_flow(df.head(1), code)
         except Exception as e:
             _log.debug("Tushare get_today_money_flow(%s) failed: %s", code, e)
             return []
 
     def get_history_money_flow(self, code: str, days: int = 30) -> list[MoneyFlow]:
-        """历史资金流：默认 30 天。"""
+        """历史资金流：默认 30 天。需 2000 积分，只覆盖沪深 A 股。"""
         if not self.is_available:
             return []
         try:
@@ -633,9 +641,7 @@ class TushareAdapter:
             return []
 
         # 1. 拉不复权 K 线
-        bars = self.get_bars(
-            code, interval, AdjustmentType.NONE, start=start, end=end, limit=limit
-        )
+        bars = self.get_bars(code, interval, AdjustmentType.NONE, start=start, end=end, limit=limit)
         if not bars:
             return []
 
@@ -719,7 +725,8 @@ class TushareAdapter:
             df = self._pro.fina_indicator(**kwargs)
             if df is None or df.empty:
                 return []
-            return df.to_dict(orient="records")
+            records: list[dict[str, Any]] = df.to_dict(orient="records")
+            return records
         except Exception as e:
             _log.debug("Tushare get_financial_indicator(%s) failed: %s", code, e)
             return []
@@ -747,7 +754,8 @@ class TushareAdapter:
             df = self._pro.dividend(ts_code=ts_code, limit=limit)
             if df is None or df.empty:
                 return []
-            return df.to_dict(orient="records")
+            records: list[dict[str, Any]] = df.to_dict(orient="records")
+            return records
         except Exception as e:
             _log.debug("Tushare get_dividend_history(%s) failed: %s", code, e)
             return []
@@ -779,7 +787,8 @@ class TushareAdapter:
             df = self._pro.income(**kwargs)
             if df is None or df.empty:
                 return []
-            return df.to_dict(orient="records")
+            records: list[dict[str, Any]] = df.to_dict(orient="records")
+            return records
         except Exception as e:
             _log.debug("Tushare get_income_statement(%s) failed: %s", code, e)
             return []
@@ -804,7 +813,8 @@ class TushareAdapter:
             df = self._pro.balancesheet(**kwargs)
             if df is None or df.empty:
                 return []
-            return df.to_dict(orient="records")
+            records: list[dict[str, Any]] = df.to_dict(orient="records")
+            return records
         except Exception as e:
             _log.debug("Tushare get_balance_sheet(%s) failed: %s", code, e)
             return []
@@ -830,7 +840,8 @@ class TushareAdapter:
             df = self._pro.cashflow(**kwargs)
             if df is None or df.empty:
                 return []
-            return df.to_dict(orient="records")
+            records: list[dict[str, Any]] = df.to_dict(orient="records")
+            return records
         except Exception as e:
             _log.debug("Tushare get_cash_flow(%s) failed: %s", code, e)
             return []
@@ -855,7 +866,8 @@ class TushareAdapter:
             df = self._pro.stock_basic(list_status=list_status)
             if df is None or df.empty:
                 return []
-            return df.to_dict(orient="records")
+            records: list[dict[str, Any]] = df.to_dict(orient="records")
+            return records
         except Exception as e:
             _log.debug("Tushare list_all_stocks failed: %s", e)
             return []

--- a/src/mommy_chaogu/market_data/utils.py
+++ b/src/mommy_chaogu/market_data/utils.py
@@ -1,0 +1,96 @@
+"""market_data 工具函数：跨 adapter 共用。
+
+目前包含：
+- `detect_market`: 根据 6 位代码头推断市场类型（沪深北）
+
+放在这里是为了避免在每个 adapter 里复制粘贴（之前 efinance 和 tushare 两边都写
+一遍，且都有漏掉北交所的 bug）。
+"""
+
+from __future__ import annotations
+
+from mommy_chaogu.market_data.types import MarketType
+
+# A 股代码前缀规则（按出现频率排序，靠前的先匹配）
+# 参考：
+# - 沪 A 主板：60xxxx, 601xxx, 603xxx, 605xxx
+# - 沪 A 科创板：688xxx, 689xxx
+# - 深 A 主板：000xxx, 001xxx, 002xxx, 003xxx
+# - 深 A 创业板：300xxx, 301xxx
+# - 北 A（北交所）：83xxxx, 87xxxx, 88xxxx, 92xxxx（新）
+#               40xxxx, 42xxxx, 43xxxx（老三板）
+# - 沪基金/债券：51xxxx, 56xxxx, 15xxxx, 16xxxx, 18xxxx
+# - 深基金/债券：10xxxx, 11xxxx, 12xxxx, 13xxxx, 14xxxx
+# 注：本函数只做"股票/基金"的市场归属判断，更细的品种分类（QuoteType）由 adapter 处理
+
+# 北交所代码前缀（独立最优先，避免被其它规则误匹配）
+_BJ_PREFIXES: tuple[str, ...] = ("83", "87", "88", "92", "40", "42", "43")
+
+# 上证（SH）股票/基金/债券前缀
+_SH_STOCK_PREFIXES: tuple[str, ...] = ("60", "68")  # 主板 + 科创板
+_SH_FUND_BOND_PREFIXES: tuple[str, ...] = ("51", "56", "15", "16", "18")
+
+# 深证（SZ）股票/基金/债券前缀
+_SZ_STOCK_PREFIXES: tuple[str, ...] = ("00", "30")  # 主板 + 创业板
+_SZ_FUND_BOND_PREFIXES: tuple[str, ...] = ("10", "11", "12", "13", "14")
+
+
+def detect_market(code: str) -> MarketType:
+    """根据 6 位 A 股代码推断所属市场（SH/SZ/BJ）。
+
+    Args:
+        code: 6 位股票代码（不含后缀），如 '600519' / '830799' / '000001'
+
+    Returns:
+        MarketType.SH / MarketType.SZ / MarketType.BJ / MarketType.UNKNOWN
+
+    规则（按优先级）：
+        1. 北交所前缀 → BJ
+        2. 沪股票前缀（60, 68）→ SH
+        3. 深股票前缀（00, 30）→ SZ
+        4. 沪基金/债券前缀 → SH
+        5. 深基金/债券前缀 → SZ
+        6. 其它 → UNKNOWN
+
+    Examples:
+        >>> detect_market("600519")
+        <MarketType.SH: 'SH'>
+        >>> detect_market("830799")  # 北交所
+        <MarketType.BJ: 'BJ'>
+        >>> detect_market("000001")
+        <MarketType.SZ: 'SZ'>
+        >>> detect_market("301236")  # 创业板
+        <MarketType.SZ: 'SZ'>
+        >>> detect_market("688981")  # 科创板
+        <MarketType.SH: 'SH'>
+        >>> detect_market("920xxx")  # 北证
+        <MarketType.BJ: 'BJ'>
+    """
+    # 非字符串（None / int / 异常类型）一律 UNKNOWN，避免 AttributeError
+    if not isinstance(code, str) or not code or not code.isdigit() or len(code) < 2:
+        return MarketType.UNKNOWN
+
+    prefix2 = code[:2]
+    prefix3 = code[:3] if len(code) >= 3 else prefix2
+
+    # 1. 北交所：83/87/88/92/40/42/43
+    if prefix2 in _BJ_PREFIXES or prefix3 in _BJ_PREFIXES:
+        return MarketType.BJ
+
+    # 2. 沪股票：60, 68（科创板 688/689）
+    if prefix2 in _SH_STOCK_PREFIXES:
+        return MarketType.SH
+
+    # 3. 深股票：00, 30（创业板 300/301）
+    if prefix2 in _SZ_STOCK_PREFIXES:
+        return MarketType.SZ
+
+    # 4. 沪基金/债券：51, 56, 15, 16, 18
+    if prefix2 in _SH_FUND_BOND_PREFIXES:
+        return MarketType.SH
+
+    # 5. 深基金/债券：10, 11, 12, 13, 14
+    if prefix2 in _SZ_FUND_BOND_PREFIXES:
+        return MarketType.SZ
+
+    return MarketType.UNKNOWN

--- a/src/mommy_chaogu/tui/services/bootstrap.py
+++ b/src/mommy_chaogu/tui/services/bootstrap.py
@@ -178,14 +178,15 @@ class Services:
     def bootstrap(cls) -> Services:
         """生产环境装配：从项目内部构建 adapter + agent。"""
         load_dotenv()
-        from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+        from mommy_chaogu.cache import CacheStore
         from mommy_chaogu.db_paths import AGENT_DB, MARKET_DB, PORTFOLIO_DB
-        from mommy_chaogu.market_data import EfinanceAdapter, FallbackAdapter, TencentAdapter
+        from mommy_chaogu.market_data import build_default_adapter
         from mommy_chaogu.portfolio.store import PortfolioStore
         from mommy_chaogu.watchlist.store import WatchlistStore
 
-        base = FallbackAdapter([EfinanceAdapter(), TencentAdapter()])  # type: ignore[list-item]
-        adapter = CachedMarketDataAdapter(base, CacheStore(MARKET_DB))  # type: ignore[arg-type]
+        adapter = build_default_adapter(
+            with_cache=True, cache_store=CacheStore(MARKET_DB)
+        )
         data_svc = DataService(
             adapter=adapter,
             watchlist_store=WatchlistStore(PORTFOLIO_DB),

--- a/src/mommy_chaogu/web/deps.py
+++ b/src/mommy_chaogu/web/deps.py
@@ -16,14 +16,9 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
-from mommy_chaogu.cache import CachedMarketDataAdapter, CacheStore
+from mommy_chaogu.cache import CacheStore
 from mommy_chaogu.db_paths import AGENT_DB, MARKET_DB, PORTFOLIO_DB
-from mommy_chaogu.market_data import (
-    EfinanceAdapter,
-    FallbackAdapter,
-    MarketDataAdapter,
-    TencentAdapter,
-)
+from mommy_chaogu.market_data import MarketDataAdapter
 from mommy_chaogu.portfolio import PortfolioStore
 from mommy_chaogu.signals import Alerter, SignalStore
 from mommy_chaogu.watchlist import WatchlistStore
@@ -62,11 +57,9 @@ def get_adapter() -> MarketDataAdapter:
     - Fallback：主源挂 → 备源
     - Cache：DB 有就用，没有才拉新，失败 fallback 旧数据
     """
-    adapter = CachedMarketDataAdapter(
-        FallbackAdapter([EfinanceAdapter(), TencentAdapter()]),
-        CacheStore(get_market_db()),
-    )
-    return adapter
+    from mommy_chaogu.market_data import build_default_adapter
+
+    return build_default_adapter(with_cache=True, cache_store=CacheStore(get_market_db()))
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_market_data/test_akshare_adapter.py
+++ b/tests/test_market_data/test_akshare_adapter.py
@@ -32,13 +32,14 @@ from mommy_chaogu.market_data.types import (
 
 @pytest.fixture
 def fake_akshare(monkeypatch: pytest.MonkeyPatch):
-    """注入一个假的 akshare 模块，提供 stock_zh_a_spot_em / stock_zh_a_hist /
-    stock_zh_a_hist_min_em 三个函数，各自返回值由测试通过 monkeypatch 设置。"""
+    """注入一个假的 akshare 模块，提供 spot/hist/min_em/fund_flow/individual_info
+    等函数，各自返回值由测试通过 monkeypatch 设置。"""
     mod = types.ModuleType("akshare")
     mod.stock_zh_a_spot_em = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
     mod.stock_zh_a_hist = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
     mod.stock_zh_a_hist_min_em = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
     mod.stock_individual_fund_flow = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
+    mod.stock_individual_info_em = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "akshare", mod)
     return mod
 
@@ -158,7 +159,7 @@ def _min_hist_df() -> pd.DataFrame:
 
 
 def _fund_flow_df() -> pd.DataFrame:
-    """模拟 stock_individual_fund_flow 返回（2 天，降序：最新在前）。
+    """模拟 stock_individual_fund_flow 返回（2 天，升序：最早在前，与真实 akshare 一致）。
 
     字段名严格按 akshare 源码 stock_fund_em.py:52-68；
     日期列是 date 对象（源码第 86 行 .dt.date）。日期相对今天，保证 days 过滤可测。
@@ -171,21 +172,6 @@ def _fund_flow_df() -> pd.DataFrame:
     d_older = today - _td(days=10)
     return pd.DataFrame(
         [
-            {
-                "日期": d_recent,
-                "收盘价": 100.0,
-                "涨跌幅": -1.96,
-                "主力净流入-净额": -2000000.0,
-                "主力净流入-净占比": -5.2,
-                "超大单净流入-净额": -1000000.0,
-                "超大单净流入-净占比": -2.6,
-                "大单净流入-净额": -1000000.0,
-                "大单净流入-净占比": -2.6,
-                "中单净流入-净额": 500000.0,
-                "中单净流入-净占比": 1.3,
-                "小单净流入-净额": 1500000.0,
-                "小单净流入-净占比": 3.9,
-            },
             {
                 "日期": d_older,
                 "收盘价": 102.0,
@@ -200,6 +186,21 @@ def _fund_flow_df() -> pd.DataFrame:
                 "中单净流入-净占比": -2.0,
                 "小单净流入-净额": -2200000.0,
                 "小单净流入-净占比": -5.5,
+            },
+            {
+                "日期": d_recent,
+                "收盘价": 100.0,
+                "涨跌幅": -1.96,
+                "主力净流入-净额": -2000000.0,
+                "主力净流入-净占比": -5.2,
+                "超大单净流入-净额": -1000000.0,
+                "超大单净流入-净占比": -2.6,
+                "大单净流入-净额": -1000000.0,
+                "大单净流入-净占比": -2.6,
+                "中单净流入-净额": 500000.0,
+                "中单净流入-净占比": 1.3,
+                "小单净流入-净额": 1500000.0,
+                "小单净流入-净占比": 3.9,
             },
         ]
     )
@@ -423,19 +424,21 @@ def test_get_bars_respects_date_range(fake_akshare) -> None:
 
 
 def test_health_check_ok(fake_akshare) -> None:
-    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    fake_akshare.stock_individual_info_em.return_value = pd.DataFrame(
+        [{"item": "股票简称", "value": "贵州茅台"}]
+    )
     a = AkShareAdapter()
     assert a.health_check() is True
 
 
 def test_health_check_empty_is_false(fake_akshare) -> None:
-    fake_akshare.stock_zh_a_spot_em.return_value = pd.DataFrame()
+    fake_akshare.stock_individual_info_em.return_value = pd.DataFrame()
     a = AkShareAdapter()
     assert a.health_check() is False
 
 
 def test_health_check_exception_is_false(fake_akshare) -> None:
-    fake_akshare.stock_zh_a_spot_em.side_effect = Exception("down")
+    fake_akshare.stock_individual_info_em.side_effect = Exception("down")
     a = AkShareAdapter()
     assert a.health_check() is False
 
@@ -444,7 +447,7 @@ def test_health_check_exception_is_false(fake_akshare) -> None:
 
 
 def test_get_today_money_flow_returns_latest(fake_akshare) -> None:
-    """当日资金流取接口返回的第一行（最新，akshare 默认降序）。"""
+    """当日资金流：取日期最大那行（today-1），不管 fixture 里它排在第几位。"""
     fake_akshare.stock_individual_fund_flow.return_value = _fund_flow_df()
     a = AkShareAdapter()
     flows = a.get_today_money_flow("600519")
@@ -457,11 +460,29 @@ def test_get_today_money_flow_returns_latest(fake_akshare) -> None:
     assert f.medium_net.amount == Decimal("500000.0")
     assert f.small_net.amount == Decimal("1500000.0")
     assert f.main_net_ratio == Decimal("-5.2")
-    # 最新一行是 today-1
+    # 日期最大那行是 today-1
     from datetime import date as _date
     from datetime import timedelta as _td
 
     assert f.timestamp.date() == _date.today() - _td(days=1)
+
+
+def test_get_today_money_flow_returns_max_date_regardless_of_input_order(
+    fake_akshare,
+) -> None:
+    """回归保护：fixture 是升序（最早在前，真实 akshare 顺序），第一行是 today-10。
+    get_today_money_flow 必须取日期最大那行（today-1），而不是 iloc[0]。
+    """
+    fake_akshare.stock_individual_fund_flow.return_value = _fund_flow_df()
+    a = AkShareAdapter()
+    flows = a.get_today_money_flow("600519")
+    assert len(flows) == 1
+    from datetime import date as _date
+    from datetime import timedelta as _td
+
+    # 取最大日期 today-1，而非第一行 today-10
+    assert flows[0].timestamp.date() == _date.today() - _td(days=1)
+    assert flows[0].timestamp.date() != _date.today() - _td(days=10)
 
 
 def test_get_today_money_flow_passes_market_suffix(fake_akshare) -> None:

--- a/tests/test_market_data/test_akshare_adapter.py
+++ b/tests/test_market_data/test_akshare_adapter.py
@@ -1,0 +1,594 @@
+"""AkShareAdapter 单元测试（不依赖网络）。
+
+通过 monkeypatch ``akshare`` 模块的函数返回固定 DataFrame，
+覆盖：spot → Quote 映射、批量、K 线（日/分钟）、健康检查、降级（无 akshare）、异常容错。
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from mommy_chaogu.market_data import (
+    AkShareAdapter,
+    MarketDataAdapter,
+    build_default_adapter,
+)
+from mommy_chaogu.market_data.types import (
+    AdjustmentType,
+    BarInterval,
+    MarketType,
+    QuoteType,
+)
+
+# ---------- 测试用 fixture ----------
+
+
+@pytest.fixture
+def fake_akshare(monkeypatch: pytest.MonkeyPatch):
+    """注入一个假的 akshare 模块，提供 stock_zh_a_spot_em / stock_zh_a_hist /
+    stock_zh_a_hist_min_em 三个函数，各自返回值由测试通过 monkeypatch 设置。"""
+    mod = types.ModuleType("akshare")
+    mod.stock_zh_a_spot_em = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
+    mod.stock_zh_a_hist = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
+    mod.stock_zh_a_hist_min_em = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
+    mod.stock_individual_fund_flow = MagicMock(return_value=pd.DataFrame())  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "akshare", mod)
+    return mod
+
+
+def _spot_df_two_rows() -> pd.DataFrame:
+    """模拟 stock_zh_a_spot_em 的两行返回（贵州茅台 + 平安银行）。"""
+    return pd.DataFrame(
+        [
+            {
+                "代码": "600519",
+                "名称": "贵州茅台",
+                "最新价": 1685.50,
+                "涨跌幅": 1.23,
+                "涨跌额": 20.45,
+                "成交量": 123456,
+                "成交额": 2080000000.0,
+                "振幅": 2.34,
+                "最高": 1699.00,
+                "最低": 1668.00,
+                "今开": 1675.00,
+                "昨收": 1665.05,
+                "量比": 0.88,
+                "换手率": 0.45,
+                "市盈率-动态": 25.6,
+                "市净率": 8.9,
+                "总市值": 2116000000000.0,
+                "流通市值": 2116000000000.0,
+            },
+            {
+                "代码": "000001",
+                "名称": "平安银行",
+                "最新价": 11.20,
+                "涨跌幅": -0.89,
+                "涨跌额": -0.10,
+                "成交量": 98765432,
+                "成交额": 1105000000.0,
+                "振幅": 1.56,
+                "最高": 11.35,
+                "最低": 11.10,
+                "今开": 11.30,
+                "昨收": 11.30,
+                "量比": 1.05,
+                "换手率": 0.51,
+                "市盈率-动态": 4.32,
+                "市净率": 0.51,
+                "总市值": 217800000000.0,
+                "流通市值": 217800000000.0,
+            },
+        ]
+    )
+
+
+def _daily_hist_df() -> pd.DataFrame:
+    """模拟 stock_zh_a_hist 日线返回（2 天）。"""
+    return pd.DataFrame(
+        [
+            {
+                "日期": "2024-01-02",
+                "开盘": 100.0,
+                "收盘": 102.0,
+                "最高": 105.0,
+                "最低": 99.0,
+                "成交量": 1000,
+                "成交额": 100000.0,
+                "振幅": 6.0,
+                "涨跌幅": 2.0,
+                "涨跌额": 2.0,
+                "换手率": 0.5,
+            },
+            {
+                "日期": "2024-01-03",
+                "开盘": 102.0,
+                "收盘": 100.0,
+                "最高": 103.0,
+                "最低": 97.0,
+                "成交量": 1100,
+                "成交额": 105000.0,
+                "振幅": 5.88,
+                "涨跌幅": -1.96,
+                "涨跌额": -2.0,
+                "换手率": 0.55,
+            },
+        ]
+    )
+
+
+def _min_hist_df() -> pd.DataFrame:
+    """模拟 stock_zh_a_hist_min_em 分钟线返回（2 根）。"""
+    return pd.DataFrame(
+        [
+            {
+                "时间": "2024-01-03 09:31:00",
+                "开盘": 102.0,
+                "收盘": 102.5,
+                "最高": 103.0,
+                "最低": 101.8,
+                "成交量": 500,
+                "成交额": 50000.0,
+                "振幅": 0.0,
+                "涨跌幅": 0.5,
+                "涨跌额": 0.5,
+            },
+            {
+                "时间": "2024-01-03 09:32:00",
+                "开盘": 102.5,
+                "收盘": 103.0,
+                "最高": 103.2,
+                "最低": 102.3,
+                "成交量": 600,
+                "成交额": 62000.0,
+                "振幅": 0.0,
+                "涨跌幅": 0.49,
+                "涨跌额": 0.5,
+            },
+        ]
+    )
+
+
+def _fund_flow_df() -> pd.DataFrame:
+    """模拟 stock_individual_fund_flow 返回（2 天，降序：最新在前）。
+
+    字段名严格按 akshare 源码 stock_fund_em.py:52-68；
+    日期列是 date 对象（源码第 86 行 .dt.date）。日期相对今天，保证 days 过滤可测。
+    """
+    from datetime import date as _date
+    from datetime import timedelta as _td
+
+    today = _date.today()
+    d_recent = today - _td(days=1)
+    d_older = today - _td(days=10)
+    return pd.DataFrame(
+        [
+            {
+                "日期": d_recent,
+                "收盘价": 100.0,
+                "涨跌幅": -1.96,
+                "主力净流入-净额": -2000000.0,
+                "主力净流入-净占比": -5.2,
+                "超大单净流入-净额": -1000000.0,
+                "超大单净流入-净占比": -2.6,
+                "大单净流入-净额": -1000000.0,
+                "大单净流入-净占比": -2.6,
+                "中单净流入-净额": 500000.0,
+                "中单净流入-净占比": 1.3,
+                "小单净流入-净额": 1500000.0,
+                "小单净流入-净占比": 3.9,
+            },
+            {
+                "日期": d_older,
+                "收盘价": 102.0,
+                "涨跌幅": 2.0,
+                "主力净流入-净额": 3000000.0,
+                "主力净流入-净占比": 7.5,
+                "超大单净流入-净额": 2000000.0,
+                "超大单净流入-净占比": 5.0,
+                "大单净流入-净额": 1000000.0,
+                "大单净流入-净占比": 2.5,
+                "中单净流入-净额": -800000.0,
+                "中单净流入-净占比": -2.0,
+                "小单净流入-净额": -2200000.0,
+                "小单净流入-净占比": -5.5,
+            },
+        ]
+    )
+
+
+# ---------- Protocol 满足性 ----------
+
+
+def test_akshare_satisfies_protocol() -> None:
+    a = AkShareAdapter()
+    assert isinstance(a, MarketDataAdapter)
+    assert a.name == "akshare"
+
+
+# ---------- spot → Quote ----------
+
+
+def test_get_quote_parses_spot(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    a = AkShareAdapter()
+    q = a.get_quote("600519")
+    assert q is not None
+    assert q.code == "600519"
+    assert q.name == "贵州茅台"
+    assert q.price == Decimal("1685.50")
+    assert q.open == Decimal("1675.00")
+    assert q.high == Decimal("1699.00")
+    assert q.low == Decimal("1668.00")
+    assert q.prev_close == Decimal("1665.05")
+    assert q.change == Decimal("20.45")
+    assert q.change_pct == Decimal("1.23")
+    assert q.volume == 123456
+    assert q.turnover.amount == Decimal("2080000000.0")
+    assert q.turnover.currency == "CNY"
+    assert q.turnover_rate == Decimal("0.45")
+    assert q.volume_ratio == Decimal("0.88")
+    assert q.pe_dynamic == Decimal("25.6")
+    assert q.total_market_cap is not None
+    assert q.total_market_cap.amount == Decimal("2116000000000.0")
+    assert q.market == MarketType.SH
+    assert q.quote_type == QuoteType.STOCK
+    assert q.timestamp is not None
+
+
+def test_get_quote_unknown_code_returns_none(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    a = AkShareAdapter()
+    assert a.get_quote("999999") is None
+
+
+def test_get_quote_spot_empty_returns_none(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.get_quote("600519") is None
+
+
+def test_get_quote_spot_exception_returns_none(fake_akshare) -> None:
+    """akshare API 抛错时静默返回 None（不传染 fallback 链）。"""
+    fake_akshare.stock_zh_a_spot_em.side_effect = RuntimeError("network down")
+    a = AkShareAdapter()
+    assert a.get_quote("600519") is None
+
+
+def test_get_quote_row_missing_code_returns_none(fake_akshare) -> None:
+    """行里没有 '代码' 字段时返回 None。"""
+    fake_akshare.stock_zh_a_spot_em.return_value = pd.DataFrame([{"名称": "X"}])
+    a = AkShareAdapter()
+    assert a.get_quote("600519") is None
+
+
+# ---------- 批量 get_quotes ----------
+
+
+def test_get_quotes_filters_by_codes(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    a = AkShareAdapter()
+    qs = a.get_quotes(["600519", "000001"])
+    codes = {q.code for q in qs}
+    assert codes == {"600519", "000001"}
+
+
+def test_get_quotes_unknown_codes_return_empty(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    a = AkShareAdapter()
+    assert a.get_quotes(["999999", "888888"]) == []
+
+
+def test_get_quotes_empty_input_returns_empty(fake_akshare) -> None:
+    a = AkShareAdapter()
+    assert a.get_quotes([]) == []
+
+
+def test_get_quotes_spot_empty_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.get_quotes(["600519"]) == []
+
+
+# ---------- list_market_quotes ----------
+
+
+def test_list_market_quotes_returns_all(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    a = AkShareAdapter()
+    quotes = a.list_market_quotes()
+    assert len(quotes) == 2
+    assert {q.code for q in quotes} == {"600519", "000001"}
+
+
+def test_list_market_quotes_empty_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.list_market_quotes() == []
+
+
+def test_list_market_quotes_exception_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.side_effect = Exception("API down")
+    a = AkShareAdapter()
+    assert a.list_market_quotes() == []
+
+
+# ---------- K 线 ----------
+
+
+def test_get_daily_bars_parses_hist(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_hist.return_value = _daily_hist_df()
+    a = AkShareAdapter()
+    bars = a.get_bars("600519", BarInterval.D1, AdjustmentType.FORWARD)
+    assert len(bars) == 2
+    b0 = bars[0]
+    assert b0.code == "600519"
+    assert b0.interval == BarInterval.D1
+    assert b0.adjustment == AdjustmentType.FORWARD
+    assert b0.open == Decimal("100.0")
+    assert b0.close == Decimal("102.0")
+    assert b0.high == Decimal("105.0")
+    assert b0.low == Decimal("99.0")
+    assert b0.volume == 1000
+    assert b0.turnover.amount == Decimal("100000.0")
+    assert b0.change_pct == Decimal("2.0")
+    assert b0.turnover_rate == Decimal("0.5")
+    # 时间按升序
+    assert bars[0].timestamp < bars[1].timestamp
+
+
+def test_get_bars_passes_adjustment_param(fake_akshare) -> None:
+    """qfq / hfq / "" 正确传给 akshare。"""
+    fake_akshare.stock_zh_a_hist.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+
+    a.get_bars("600519", BarInterval.D1, AdjustmentType.FORWARD)
+    assert fake_akshare.stock_zh_a_hist.call_args.kwargs["adjust"] == "qfq"
+
+    a.get_bars("600519", BarInterval.D1, AdjustmentType.BACKWARD)
+    assert fake_akshare.stock_zh_a_hist.call_args.kwargs["adjust"] == "hfq"
+
+    a.get_bars("600519", BarInterval.D1, AdjustmentType.NONE)
+    assert fake_akshare.stock_zh_a_hist.call_args.kwargs["adjust"] == ""
+
+
+def test_get_bars_passes_daily_period(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_hist.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    a.get_bars("600519", BarInterval.W1)
+    assert fake_akshare.stock_zh_a_hist.call_args.kwargs["period"] == "weekly"
+    a.get_bars("600519", BarInterval.M)
+    assert fake_akshare.stock_zh_a_hist.call_args.kwargs["period"] == "monthly"
+
+
+def test_get_min_bars_uses_min_em_endpoint(fake_akshare) -> None:
+    """分钟线走 stock_zh_a_hist_min_em，不走 stock_zh_a_hist。"""
+    fake_akshare.stock_zh_a_hist_min_em.return_value = _min_hist_df()
+    a = AkShareAdapter()
+    bars = a.get_bars("600519", BarInterval.M5, AdjustmentType.FORWARD)
+    assert len(bars) == 2
+    assert bars[0].interval == BarInterval.M5
+    # 分钟接口被调用，日接口不被调用
+    assert fake_akshare.stock_zh_a_hist_min_em.called
+    assert not fake_akshare.stock_zh_a_hist.called
+    # period 传字符串 "5"
+    assert fake_akshare.stock_zh_a_hist_min_em.call_args.kwargs["period"] == "5"
+
+
+def test_get_bars_exception_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_hist.side_effect = RuntimeError("API timeout")
+    a = AkShareAdapter()
+    assert a.get_bars("600519", BarInterval.D1) == []
+
+
+def test_get_bars_empty_df_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_hist.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.get_bars("600519", BarInterval.D1) == []
+
+
+def test_get_bars_respects_limit(fake_akshare) -> None:
+    """limit 截断最后 N 根。"""
+    fake_akshare.stock_zh_a_hist.return_value = _daily_hist_df()
+    a = AkShareAdapter()
+    bars = a.get_bars("600519", BarInterval.D1, limit=1)
+    assert len(bars) == 1
+    # 取最后一根
+    assert bars[0].close == Decimal("100.0")
+
+
+def test_get_bars_respects_date_range(fake_akshare) -> None:
+    """start/end 过滤生效。"""
+    fake_akshare.stock_zh_a_hist.return_value = _daily_hist_df()
+    a = AkShareAdapter()
+    bars = a.get_bars(
+        "600519",
+        BarInterval.D1,
+        start=date(2024, 1, 3),
+        end=date(2024, 1, 3),
+    )
+    assert len(bars) == 1
+    assert bars[0].timestamp.date() == date(2024, 1, 3)
+
+
+# ---------- 健康检查 ----------
+
+
+def test_health_check_ok(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = _spot_df_two_rows()
+    a = AkShareAdapter()
+    assert a.health_check() is True
+
+
+def test_health_check_empty_is_false(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.health_check() is False
+
+
+def test_health_check_exception_is_false(fake_akshare) -> None:
+    fake_akshare.stock_zh_a_spot_em.side_effect = Exception("down")
+    a = AkShareAdapter()
+    assert a.health_check() is False
+
+
+# ---------- 资金流 ----------
+
+
+def test_get_today_money_flow_returns_latest(fake_akshare) -> None:
+    """当日资金流取接口返回的第一行（最新，akshare 默认降序）。"""
+    fake_akshare.stock_individual_fund_flow.return_value = _fund_flow_df()
+    a = AkShareAdapter()
+    flows = a.get_today_money_flow("600519")
+    assert len(flows) == 1
+    f = flows[0]
+    assert f.code == "600519"
+    assert f.main_net.amount == Decimal("-2000000.0")
+    assert f.super_large_net.amount == Decimal("-1000000.0")
+    assert f.large_net.amount == Decimal("-1000000.0")
+    assert f.medium_net.amount == Decimal("500000.0")
+    assert f.small_net.amount == Decimal("1500000.0")
+    assert f.main_net_ratio == Decimal("-5.2")
+    # 最新一行是 today-1
+    from datetime import date as _date
+    from datetime import timedelta as _td
+
+    assert f.timestamp.date() == _date.today() - _td(days=1)
+
+
+def test_get_today_money_flow_passes_market_suffix(fake_akshare) -> None:
+    """sh/sz/bj 后缀根据代码头正确传给接口。"""
+    fake_akshare.stock_individual_fund_flow.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    a.get_today_money_flow("600519")  # SH
+    assert fake_akshare.stock_individual_fund_flow.call_args.kwargs["market"] == "sh"
+    assert fake_akshare.stock_individual_fund_flow.call_args.kwargs["stock"] == "600519"
+
+    a.get_today_money_flow("000001")  # SZ
+    assert fake_akshare.stock_individual_fund_flow.call_args.kwargs["market"] == "sz"
+
+    a.get_today_money_flow("920001")  # BJ
+    assert fake_akshare.stock_individual_fund_flow.call_args.kwargs["market"] == "bj"
+
+
+def test_get_today_money_flow_empty_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_individual_fund_flow.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.get_today_money_flow("600519") == []
+
+
+def test_get_today_money_flow_exception_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_individual_fund_flow.side_effect = RuntimeError("API down")
+    a = AkShareAdapter()
+    assert a.get_today_money_flow("600519") == []
+
+
+def test_get_history_money_flow_returns_all(fake_akshare) -> None:
+    """历史资金流：days=30 覆盖两条（1 天 + 10 天都 ≤ 30）。"""
+    fake_akshare.stock_individual_fund_flow.return_value = _fund_flow_df()
+    a = AkShareAdapter()
+    flows = a.get_history_money_flow("600519", days=30)
+    assert len(flows) == 2
+
+
+def test_get_history_money_flow_days_filter(fake_akshare) -> None:
+    """days=5 只保留近 5 天（10 天前那条被过滤）。"""
+    fake_akshare.stock_individual_fund_flow.return_value = _fund_flow_df()
+    a = AkShareAdapter()
+    flows = a.get_history_money_flow("600519", days=5)
+    assert len(flows) == 1
+    from datetime import date as _date
+    from datetime import timedelta as _td
+
+    assert flows[0].timestamp.date() == _date.today() - _td(days=1)
+
+
+def test_get_history_money_flow_exception_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_individual_fund_flow.side_effect = Exception("network")
+    a = AkShareAdapter()
+    assert a.get_history_money_flow("600519") == []
+
+
+def test_get_history_money_flow_empty_df_returns_empty(fake_akshare) -> None:
+    fake_akshare.stock_individual_fund_flow.return_value = pd.DataFrame()
+    a = AkShareAdapter()
+    assert a.get_history_money_flow("600519") == []
+
+
+# ---------- 仍不实现的方法（返回空，留给 fallback 链）----------
+
+
+def test_unimplemented_methods_return_empty(fake_akshare) -> None:
+    """盘口/逐笔/板块反查 akshare 不实现，留给 efinance。"""
+    a = AkShareAdapter()
+    assert a.get_order_book("600519") is None
+    assert a.get_ticks("600519") == []
+    assert a.get_belonging_boards("600519") == []
+
+
+# ---------- 降级：akshare 未安装 ----------
+
+
+def test_degrades_when_akshare_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """没装 akshare 时所有方法返回 None/空，不抛 ImportError。"""
+    # 模拟 import akshare 失败
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "akshare":
+            raise ImportError("No module named 'akshare'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    # 从 sys.modules 清掉（如果之前 fake_akshare 注入过）
+    monkeypatch.delitem(sys.modules, "akshare", raising=False)
+
+    a = AkShareAdapter()
+    assert a.get_quote("600519") is None
+    assert a.get_quotes(["600519"]) == []
+    assert a.list_market_quotes() == []
+    assert a.get_bars("600519", BarInterval.D1) == []
+    assert a.health_check() is False
+
+
+# ---------- build_default_adapter 工厂 ----------
+
+
+def test_build_default_adapter_includes_akshare_when_available(
+    fake_akshare, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """akshare 可用时，工厂把它加进 fallback 链。"""
+    adapter = build_default_adapter()
+    assert "akshare" in adapter.name
+
+
+def test_build_default_adapter_skips_akshare_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """akshare 不可用时，工厂跳过它（链里只有 efinance + tencent）。"""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "akshare":
+            raise ImportError("No module named 'akshare'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.delitem(sys.modules, "akshare", raising=False)
+
+    adapter = build_default_adapter()
+    assert "akshare" not in adapter.name
+    assert "efinance" in adapter.name
+    assert "tencent" in adapter.name

--- a/tests/test_market_data/test_akshare_network.py
+++ b/tests/test_market_data/test_akshare_network.py
@@ -1,0 +1,124 @@
+"""AkShareAdapter 真实联网冒烟测试。
+
+目的：现有 36 个 AkShare 测试全是 mock，从不真正打 akshare API，所以
+akshare 改了中文列名（``市盈率-动态`` / ``主力净流入-净额`` 等）时单测照样
+绿——这正是之前 Tushare 集成补丁里凭空捏造字段名、上线才发现坏的根因。
+本文件直接打东财后端，把 adapter 依赖的列名假设钉死在真实 API 上。
+
+测试运行需要联网（push2his.eastmoney.com）。默认被 ``pytest -m "not network"``
+跳过；要真正跑：``uv run --extra dev pytest -m network tests/test_market_data/test_akshare_network.py``。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mommy_chaogu.market_data import (
+    AdjustmentType,
+    AkShareAdapter,
+    BarInterval,
+    Money,
+)
+
+
+@pytest.fixture(scope="module")
+def adp() -> AkShareAdapter:
+    return AkShareAdapter()
+
+
+# ---------- 实时报价：PE/PB/市值 列名 ----------
+
+
+@pytest.mark.network
+def test_network_get_quote_real_fields(adp: AkShareAdapter) -> None:
+    """Guard: ``stock_zh_a_spot_em`` 的 PE/PB/市值中文列名映射。
+
+    akshare 相对 efinance 的核心增量就是实时快照里给全 PE/PB/总市值/流通市值/
+    换手率/量比。如果 akshare 把 ``市盈率-动态`` / ``总市值`` 等列名改了，
+    ``_spot_row_to_quote`` 会静默拿不到值（``row.get`` 返回 None），这里通过
+    断言 ``pe_dynamic`` / ``total_market_cap`` 非空把它钉死在真实 API 上。
+    用 600519（贵州茅台）——大盘蓝筹，PE/市值永远有值。
+    """
+    q = adp.get_quote("600519")
+    assert q is not None, "get_quote 返回 None，可能 spot 接口整体挂了"
+    assert q.code == "600519"
+    assert q.price > 0, "最新价应为正"
+    assert q.pe_dynamic is not None, "市盈率-动态 列名映射失败或字段缺失"
+    assert q.total_market_cap is not None, "总市值 列名映射失败或字段缺失"
+    assert q.total_market_cap.amount > 0
+
+
+# ---------- K 线：OHLC/量/额 列名 + 数据合理性 ----------
+
+
+@pytest.mark.network
+def test_network_get_bars_daily_real_ohlc(adp: AkShareAdapter) -> None:
+    """Guard: ``stock_zh_a_hist`` 的 K 线中文列名映射 + 数值合理性。
+
+    依赖的列名：``开盘 / 收盘 / 最高 / 最低 / 成交量 / 成交额 / 日期``。
+    ``stock_zh_a_hist`` 是 akshare 的 KeyError 重灾区（akfamily/akshare 一堆
+    issue），列名版本飘移会直接 KeyError 拿到空列表。这里用前复权日线、
+    limit=5，断言每根 bar 的 OHLC/量额都合理。
+    """
+    bars = adp.get_bars(
+        "600519",
+        BarInterval.D1,
+        AdjustmentType.FORWARD,
+        limit=5,
+    )
+    assert bars, "get_bars 返回空，可能 stock_zh_a_hist 列名变了或接口失败"
+    for b in bars:
+        assert b.high >= b.low, f"{b.timestamp}: high({b.high}) < low({b.low})"
+        assert b.low <= b.close <= b.high, (
+            f"{b.timestamp}: close({b.close}) 不在 [{b.low}, {b.high}] 内"
+        )
+        assert b.open > 0, f"{b.timestamp}: open={b.open} 非正"
+        assert b.volume >= 0, f"{b.timestamp}: volume={b.volume} 为负"
+        assert b.turnover.amount > 0, (
+            f"{b.timestamp}: 成交额={b.turnover.amount} 非正（成交额 列名映射失败?）"
+        )
+
+
+# ---------- 资金流：主力/超大/大/中/小单 列名（最关键）----------
+
+
+@pytest.mark.network
+def test_network_history_money_flow_real_fields(adp: AkShareAdapter) -> None:
+    """Guard: ``stock_individual_fund_flow`` 的资金流中文列名映射。
+
+    **这是本文件存在的核心原因。** 之前 Tushare 集成补丁里凭空捏造了资金流
+    字段名、上线直接坏掉，根因就是没有任何联网测试去对真实列名。akshare 的
+    资金流接口列名是中文且易飘：``主力净流入-净额 / 超大单净流入-净额 /
+    大单净流入-净额 / 中单净流入-净额 / 小单净流入-净额``。这里断言：
+    1. 返回非空（接口没整列 KeyError）；
+    2. 各档位都是 ``Money`` 对象（列名没改名导致拿到 None→默认 0 也能过，
+       所以进一步要求至少有一行 ``main_net`` 真实非零，确认不是全默认值）。
+    用 days=10 给接口一点回旋余地。
+    """
+    flows = adp.get_history_money_flow("600519", days=10)
+    assert flows, "get_history_money_flow 返回空，资金流接口列名可能已变"
+
+    for f in flows:
+        assert isinstance(f.main_net, Money)
+        assert isinstance(f.super_large_net, Money)
+        assert isinstance(f.large_net, Money)
+        assert isinstance(f.medium_net, Money)
+        assert isinstance(f.small_net, Money)
+
+    # 至少一行主力净流入真实非零——否则列名改名后全拿 None→默认 0 也能蒙混。
+    assert any(f.main_net.amount != 0 for f in flows), (
+        "所有行 main_net 都是 0，主力净流入-净额 列名映射几乎肯定坏了"
+    )
+
+
+# ---------- 健康检查 ----------
+
+
+@pytest.mark.network
+def test_network_health_check(adp: AkShareAdapter) -> None:
+    """Guard: health_check 能拉到一行 spot 即视为可用。
+
+    health_check 是 fallback 链判定 akshare 启停的依据，必须真实打通
+    ``stock_zh_a_spot_em`` 才返回 True。
+    """
+    assert adp.health_check() is True

--- a/tests/test_market_data/test_tushare_adapter.py
+++ b/tests/test_market_data/test_tushare_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
@@ -78,19 +79,19 @@ class TestTushareAdapterInit:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake_token_xxx"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                adp = TushareAdapter()
-                # 初始化过程中会调 tushare.set_token + tushare.pro_api
-                assert adp._token == "fake_token_xxx"
-                # pro_api 被调用过（fake_token 也走通）
-                mock_pro.assert_called_once()
+            adp = TushareAdapter()
+            # 初始化过程中会调 tushare.set_token + tushare.pro_api
+            assert adp._token == "fake_token_xxx"
+            # pro_api 被调用过（fake_token 也走通）
+            mock_pro.assert_called_once()
 
     def test_explicit_token_override(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "env_token"}),
             patch("tushare.pro_api"),
         ):
-                adp = TushareAdapter(token="explicit_token")
-                assert adp._token == "explicit_token"
+            adp = TushareAdapter(token="explicit_token")
+            assert adp._token == "explicit_token"
 
 
 # ---------- 方法在没有 token 时的退化行为 ----------
@@ -146,9 +147,9 @@ class TestTushareAdapterRobustness:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                # 让 pro_api 返回一个 mock，所有 query 抛异常
-                mock_pro.return_value.query.side_effect = Exception("API down")
-                return TushareAdapter()
+            # 让 pro_api 返回一个 mock，所有 query 抛异常
+            mock_pro.return_value.query.side_effect = Exception("API down")
+            return TushareAdapter()
 
     def test_quote_handles_exception(self, adp: TushareAdapter) -> None:
         assert adp.get_quote("600519") is None
@@ -179,13 +180,14 @@ class TestTushareBarsAdjustment:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.query.side_effect = Exception("not used")
-                return TushareAdapter()
+            mock_pro.return_value.query.side_effect = Exception("not used")
+            return TushareAdapter()
 
     def test_forward_adjustment_passes_qfq(self, adp_with_token: TushareAdapter) -> None:
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             # 模拟 pro_bar 返回空 DataFrame
             import pandas as pd
+
             mock_pro_bar.return_value = pd.DataFrame()
 
             adp_with_token.get_bars("600519", BarInterval.D1, AdjustmentType.FORWARD)
@@ -196,6 +198,7 @@ class TestTushareBarsAdjustment:
     def test_backward_adjustment_passes_hfq(self, adp_with_token: TushareAdapter) -> None:
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             import pandas as pd
+
             mock_pro_bar.return_value = pd.DataFrame()
 
             adp_with_token.get_bars("600519", BarInterval.D1, AdjustmentType.BACKWARD)
@@ -205,6 +208,7 @@ class TestTushareBarsAdjustment:
     def test_no_adjustment_passes_none(self, adp_with_token: TushareAdapter) -> None:
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             import pandas as pd
+
             mock_pro_bar.return_value = pd.DataFrame()
 
             adp_with_token.get_bars("600519", BarInterval.D1, AdjustmentType.NONE)
@@ -214,20 +218,29 @@ class TestTushareBarsAdjustment:
     def test_d1_interval_passes_d_freq(self, adp_with_token: TushareAdapter) -> None:
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             import pandas as pd
+
             mock_pro_bar.return_value = pd.DataFrame()
 
             adp_with_token.get_bars("600519", BarInterval.D1)
             call_kwargs = mock_pro_bar.call_args.kwargs
             assert call_kwargs.get("freq") == "D"
 
-    def test_m5_interval_passes_5min_freq(self, adp_with_token: TushareAdapter) -> None:
-        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
-            import pandas as pd
-            mock_pro_bar.return_value = pd.DataFrame()
+    def test_minute_intervals_not_supported(self, adp_with_token: TushareAdapter) -> None:
+        """分钟线（M1~M60）显式不支持：直接返回 []，且不调用 pro_bar。
 
-            adp_with_token.get_bars("600519", BarInterval.M5)
-            call_kwargs = mock_pro_bar.call_args.kwargs
-            assert call_kwargs.get("freq") == "5min"
+        原因：stk_mins 需单独积分权限，且 pro_bar 在 adj≠None 时会 drop 掉
+        trade_date 列（只剩 trade_time），静默返回空不如直接拒绝。
+        """
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            for interval in (
+                BarInterval.M1,
+                BarInterval.M5,
+                BarInterval.M15,
+                BarInterval.M30,
+                BarInterval.M60,
+            ):
+                assert adp_with_token.get_bars("600519", interval) == []
+            assert not mock_pro_bar.called
 
     def test_pro_bar_exception_returns_empty(self, adp_with_token: TushareAdapter) -> None:
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
@@ -265,9 +278,10 @@ def _make_bars(prices: list[tuple[str, str, str, str, str]]) -> list[Bar]:
 class TestApplyAdjustment:
     """验证前/后复权算法。
 
-    复权逻辑:
-        前复权:  adj = raw * (latest / current)  → 最新价不变
-        后复权:  adj = raw * (earliest / current)  → 最早价不变
+    Tushare adj_factor 上市首日=1，随分红送股**递增**（越晚越大，如 000001.SZ
+    2018 年已 108.031）。复权逻辑（与 pro_bar 的 qfq 公式一致）:
+        前复权:  adj = raw * (current / latest)    → 最新价不变，历史价压低
+        后复权:  adj = raw * (current / earliest)  → 最早价不变
     """
 
     def test_no_adjustment_returns_unchanged(self) -> None:
@@ -288,16 +302,20 @@ class TestApplyAdjustment:
     def test_forward_adjustment_keeps_latest_price(self) -> None:
         """前复权：最新一天的收盘价应该等于原始收盘价。"""
         # 3 天 K 线，价格不变
-        bars = _make_bars([
-            ("2024-01-02", "100", "105", "99", "102"),
-            ("2024-01-03", "102", "107", "101", "105"),
-            ("2024-01-04", "105", "110", "104", "108"),
-        ])
+        bars = _make_bars(
+            [
+                ("2024-01-02", "100", "105", "99", "102"),
+                ("2024-01-03", "102", "107", "101", "105"),
+                ("2024-01-04", "105", "110", "104", "108"),
+            ]
+        )
         # 复权因子：1/2 = 1.0, 1/3 = 1.0, 1/4 = 1.0 (未除权)
-        factors = pd.DataFrame({
-            "trade_date": ["20240102", "20240103", "20240104"],
-            "adj_factor": [1.0, 1.0, 1.0],
-        })
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102", "20240103", "20240104"],
+                "adj_factor": [1.0, 1.0, 1.0],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
         # 因子全 1.0，比例 = 1.0 / 1.0 = 1.0 → 价不变
         assert result[2].close == bars[2].close  # 108
@@ -307,40 +325,48 @@ class TestApplyAdjustment:
     def test_forward_adjustment_handles_dividend(self) -> None:
         """前复权：发生除权后，历史价会下调。"""
         # 2 天 K 线：第一天除权前，第二天除权后
-        bars = _make_bars([
-            ("2024-01-02", "100", "105", "99", "102"),  # 除权前
-            ("2024-01-03", "98", "103", "97", "100"),    # 除权后
-        ])
-        # 复权因子：除权日因子变小（说明除权了）
-        # 2024-01-02: adj_factor = 2.0 (基准)
-        # 2024-01-03: adj_factor = 1.0 (除权后)
-        factors = pd.DataFrame({
-            "trade_date": ["20240102", "20240103"],
-            "adj_factor": [2.0, 1.0],
-        })
+        bars = _make_bars(
+            [
+                ("2024-01-02", "100", "105", "99", "102"),  # 除权前
+                ("2024-01-03", "98", "103", "97", "100"),  # 除权后
+            ]
+        )
+        # Tushare 因子随分红送股递增：除权后因子变大
+        # 2024-01-02: adj_factor = 1.0 (除权前)
+        # 2024-01-03: adj_factor = 2.0 (除权后，最新)
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102", "20240103"],
+                "adj_factor": [1.0, 2.0],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
-        # 前复权: ratio = latest_factor / current_factor
+        # 前复权: ratio = current_factor / latest_factor
         #   2024-01-02: ratio = 1.0 / 2.0 = 0.5  → 价减半
-        #   2024-01-03: ratio = 1.0 / 1.0 = 1.0  → 价不变
+        #   2024-01-03: ratio = 2.0 / 2.0 = 1.0  → 价不变
         assert result[1].close == 100  # 最新价不变
-        assert result[0].close == 51    # 历史价减半 (102 * 0.5)
+        assert result[0].close == 51  # 历史价减半 (102 * 0.5)
         # OHLC 都要调整
-        assert result[0].open == 50    # 100 * 0.5
+        assert result[0].open == 50  # 100 * 0.5
         assert result[0].high == Decimal("52.5")  # 105 * 0.5
 
     def test_backward_adjustment_keeps_earliest_price(self) -> None:
         """后复权：最早一天的收盘价应该等于原始收盘价。"""
-        bars = _make_bars([
-            ("2024-01-02", "100", "105", "99", "102"),
-            ("2024-01-03", "98", "103", "97", "100"),
-        ])
-        factors = pd.DataFrame({
-            "trade_date": ["20240102", "20240103"],
-            "adj_factor": [2.0, 1.0],
-        })
+        bars = _make_bars(
+            [
+                ("2024-01-02", "100", "105", "99", "102"),
+                ("2024-01-03", "98", "103", "97", "100"),
+            ]
+        )
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102", "20240103"],
+                "adj_factor": [1.0, 2.0],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.BACKWARD)
-        # 后复权: ratio = earliest_factor / current_factor
-        #   2024-01-02: ratio = 2.0 / 2.0 = 1.0  → 价不变
+        # 后复权: ratio = current_factor / earliest_factor
+        #   2024-01-02: ratio = 1.0 / 1.0 = 1.0  → 价不变
         #   2024-01-03: ratio = 2.0 / 1.0 = 2.0  → 价倍增
         assert result[0].close == 102  # 最早价不变
         assert result[1].close == 200  # 100 * 2.0
@@ -348,10 +374,12 @@ class TestApplyAdjustment:
     def test_ohlc_all_adjusted_consistently(self) -> None:
         """前复权后，OHLC 之间的相对关系（high >= close 等）保持。"""
         bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
-        factors = pd.DataFrame({
-            "trade_date": ["20240102"],
-            "adj_factor": [0.5],
-        })
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102"],
+                "adj_factor": [0.5],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
         assert result[0].high >= result[0].low
         assert result[0].high >= result[0].close
@@ -363,51 +391,67 @@ class TestApplyAdjustment:
         """成交量不复权（除权除息不影响量）。"""
         bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
         bars[0] = Bar(
-            code=bars[0].code, name=bars[0].name, interval=bars[0].interval,
-            adjustment=bars[0].adjustment, timestamp=bars[0].timestamp,
-            open=bars[0].open, high=bars[0].high, low=bars[0].low, close=bars[0].close,
+            code=bars[0].code,
+            name=bars[0].name,
+            interval=bars[0].interval,
+            adjustment=bars[0].adjustment,
+            timestamp=bars[0].timestamp,
+            open=bars[0].open,
+            high=bars[0].high,
+            low=bars[0].low,
+            close=bars[0].close,
             volume=12345,  # 原始成交量
             turnover=Money(Decimal("67890"), "CNY"),
         )
-        factors = pd.DataFrame({
-            "trade_date": ["20240102"],
-            "adj_factor": [0.5],
-        })
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102"],
+                "adj_factor": [0.5],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
         assert result[0].volume == 12345  # 成交量不变
 
     def test_missing_factor_for_date_keeps_bar_unchanged(self) -> None:
         """中间某个 bar 找不到因子：只跳过那根，其他正常调整。"""
-        bars = _make_bars([
-            ("2024-01-02", "100", "105", "99", "102"),
-            ("2024-01-03", "200", "210", "198", "204"),  # 没因子
-            ("2024-01-04", "98", "103", "97", "100"),
-        ])
+        bars = _make_bars(
+            [
+                ("2024-01-02", "100", "105", "99", "102"),
+                ("2024-01-03", "200", "210", "198", "204"),  # 没因子
+                ("2024-01-04", "98", "103", "97", "100"),
+            ]
+        )
         # 给了 2024-01-02 和 2024-01-04 的因子，2024-01-03 缺失
-        factors = pd.DataFrame({
-            "trade_date": ["20240102", "20240104"],
-            "adj_factor": [2.0, 1.0],  # 最新因子 = 1.0
-        })
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102", "20240104"],
+                "adj_factor": [1.0, 2.0],  # 最新因子 = 2.0
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
-        # 第 1 根：2024-01-02, factor=2.0, ratio = 1.0/2.0 = 0.5 → close 减半
+        # 第 1 根：2024-01-02, factor=1.0, ratio = 1.0/2.0 = 0.5 → close 减半
         assert result[0].close == 51  # 102 * 0.5
         # 第 2 根：2024-01-03 找不到因子 → 跳过调整，保持原值
         assert result[1].close == 204
-        # 第 3 根：2024-01-04, factor=1.0, ratio = 1.0/1.0 = 1.0 → 不变
+        # 第 3 根：2024-01-04, factor=2.0, ratio = 2.0/2.0 = 1.0 → 不变
         assert result[2].close == 100
 
     def test_missing_anchor_factor_returns_unchanged(self) -> None:
         """如果最新/最旧那根 bar 找不到因子（锚点丢失），安全返回原始 bars。"""
         # 缺 2024-01-04 的因子（最新 bar 锚点）
-        bars = _make_bars([
-            ("2024-01-02", "100", "105", "99", "102"),
-            ("2024-01-03", "98", "103", "97", "100"),
-            ("2024-01-04", "200", "210", "198", "204"),
-        ])
-        factors = pd.DataFrame({
-            "trade_date": ["20240102", "20240103"],  # 缺 2024-01-04
-            "adj_factor": [2.0, 1.0],
-        })
+        bars = _make_bars(
+            [
+                ("2024-01-02", "100", "105", "99", "102"),
+                ("2024-01-03", "98", "103", "97", "100"),
+                ("2024-01-04", "200", "210", "198", "204"),
+            ]
+        )
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102", "20240103"],  # 缺 2024-01-04
+                "adj_factor": [2.0, 1.0],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
         # 锚点丢失 → 全部保持原值
         assert result[0].close == 102
@@ -417,10 +461,12 @@ class TestApplyAdjustment:
     def test_accepts_timestamp_dates(self) -> None:
         """trade_date 可以是 Timestamp / date，不一定必须是字符串。"""
         bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
-        factors = pd.DataFrame({
-            "trade_date": [pd.Timestamp("2024-01-02")],
-            "adj_factor": [1.0],
-        })
+        factors = pd.DataFrame(
+            {
+                "trade_date": [pd.Timestamp("2024-01-02")],
+                "adj_factor": [1.0],
+            }
+        )
         result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
         assert result[0].close == 102  # factor=1.0 不变
 
@@ -428,10 +474,12 @@ class TestApplyAdjustment:
         """重要：原 bars 列表不能被修改（Bar 是 frozen dataclass，自然满足）。"""
         bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
         original_close = bars[0].close
-        factors = pd.DataFrame({
-            "trade_date": ["20240102"],
-            "adj_factor": [0.5],
-        })
+        factors = pd.DataFrame(
+            {
+                "trade_date": ["20240102"],
+                "adj_factor": [0.5],
+            }
+        )
         _ = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
         # 原 bar 不变
         assert bars[0].close == original_close
@@ -447,8 +495,8 @@ class TestFetchAndAdjust:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.query.side_effect = Exception("not used")
-                return TushareAdapter()
+            mock_pro.return_value.query.side_effect = Exception("not used")
+            return TushareAdapter()
 
     def test_returns_empty_when_no_token(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
@@ -460,6 +508,7 @@ class TestFetchAndAdjust:
     def test_returns_empty_when_get_bars_empty(self, adp_with_token: TushareAdapter) -> None:
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             import pandas as pd
+
             mock_pro_bar.return_value = pd.DataFrame()
             result = adp_with_token.fetch_and_adjust("600519")
             assert result == []
@@ -468,24 +517,29 @@ class TestFetchAndAdjust:
         """完整流程：拉 K 线 + 拉因子 + 应用复权。"""
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             import pandas as pd
+
             # 模拟 pro_bar 返回 2 根 K 线
-            mock_pro_bar.return_value = pd.DataFrame({
-                "trade_date": ["20240102", "20240103"],
-                "open": [100.0, 98.0],
-                "high": [105.0, 103.0],
-                "low": [99.0, 97.0],
-                "close": [102.0, 100.0],
-                "vol": [1000, 1100],
-                "amount": [100000.0, 105000.0],
-            })
-            # mock adj_factor
-            adp_with_token._pro.adj_factor = MagicMock(return_value=pd.DataFrame({
-                "trade_date": ["20240102", "20240103"],
-                "adj_factor": [2.0, 1.0],
-            }))
-            result = adp_with_token.fetch_and_adjust(
-                "600519", mode=AdjustmentType.FORWARD
+            mock_pro_bar.return_value = pd.DataFrame(
+                {
+                    "trade_date": ["20240102", "20240103"],
+                    "open": [100.0, 98.0],
+                    "high": [105.0, 103.0],
+                    "low": [99.0, 97.0],
+                    "close": [102.0, 100.0],
+                    "vol": [1000, 1100],
+                    "amount": [100000.0, 105000.0],
+                }
             )
+            # mock adj_factor（Tushare 真实语义：因子随分红送股递增）
+            adp_with_token._pro.adj_factor = MagicMock(
+                return_value=pd.DataFrame(
+                    {
+                        "trade_date": ["20240102", "20240103"],
+                        "adj_factor": [1.0, 2.0],
+                    }
+                )
+            )
+            result = adp_with_token.fetch_and_adjust("600519", mode=AdjustmentType.FORWARD)
             assert len(result) == 2
             # 前复权：最新价（result[1]）= 100 不变；历史价（result[0]）减半
             assert result[1].close == 100
@@ -495,11 +549,18 @@ class TestFetchAndAdjust:
         """adj_factor 失败时降级返回原始 K 线（不抛异常）。"""
         with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
             import pandas as pd
-            mock_pro_bar.return_value = pd.DataFrame({
-                "trade_date": ["20240102"],
-                "open": [100.0], "high": [105.0], "low": [99.0], "close": [102.0],
-                "vol": [1000], "amount": [100000.0],
-            })
+
+            mock_pro_bar.return_value = pd.DataFrame(
+                {
+                    "trade_date": ["20240102"],
+                    "open": [100.0],
+                    "high": [105.0],
+                    "low": [99.0],
+                    "close": [102.0],
+                    "vol": [1000],
+                    "amount": [100000.0],
+                }
+            )
             adp_with_token._pro.adj_factor = MagicMock(side_effect=Exception("API down"))
             result = adp_with_token.fetch_and_adjust("600519")
             assert len(result) == 1
@@ -522,7 +583,7 @@ class TestTushareFinancials:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                return TushareAdapter(), mock_pro
+            return TushareAdapter(), mock_pro
 
     def test_financial_indicator_no_token(self, adp_no_token: TushareAdapter) -> None:
         assert adp_no_token.get_financial_indicator("600519") == []
@@ -532,130 +593,142 @@ class TestTushareFinancials:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.fina_indicator.return_value = pd.DataFrame({
+            mock_pro.return_value.fina_indicator.return_value = pd.DataFrame(
+                {
                     "ts_code": ["600519.SH"],
                     "end_date": ["20240930"],
                     "roe": [25.5],
                     "gross_profit_margin": [91.2],
-                })
-                adp = TushareAdapter()
-                result = adp.get_financial_indicator("600519", period="20240930")
-                assert len(result) == 1
-                assert result[0]["roe"] == 25.5
-                # 参数传递验证
-                call_kwargs = mock_pro.return_value.fina_indicator.call_args.kwargs
-                assert call_kwargs["ts_code"] == "600519.SH"
-                assert call_kwargs["period"] == "20240930"
+                }
+            )
+            adp = TushareAdapter()
+            result = adp.get_financial_indicator("600519", period="20240930")
+            assert len(result) == 1
+            assert result[0]["roe"] == 25.5
+            # 参数传递验证
+            call_kwargs = mock_pro.return_value.fina_indicator.call_args.kwargs
+            assert call_kwargs["ts_code"] == "600519.SH"
+            assert call_kwargs["period"] == "20240930"
 
     def test_financial_indicator_handles_exception(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.fina_indicator.side_effect = Exception("API down")
-                adp = TushareAdapter()
-                result = adp.get_financial_indicator("600519")
-                assert result == []
+            mock_pro.return_value.fina_indicator.side_effect = Exception("API down")
+            adp = TushareAdapter()
+            result = adp.get_financial_indicator("600519")
+            assert result == []
 
     def test_dividend_history(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.dividend.return_value = pd.DataFrame({
+            mock_pro.return_value.dividend.return_value = pd.DataFrame(
+                {
                     "ts_code": ["600519.SH"] * 3,
                     "end_date": ["20231231", "20221231", "20211231"],
                     "cash_div": [30.88, 21.91, 19.29],
-                })
-                adp = TushareAdapter()
-                result = adp.get_dividend_history("600519", limit=3)
-                assert len(result) == 3
-                assert result[0]["cash_div"] == 30.88
-                call_kwargs = mock_pro.return_value.dividend.call_args.kwargs
-                assert call_kwargs["ts_code"] == "600519.SH"
-                assert call_kwargs["limit"] == 3
+                }
+            )
+            adp = TushareAdapter()
+            result = adp.get_dividend_history("600519", limit=3)
+            assert len(result) == 3
+            assert result[0]["cash_div"] == 30.88
+            call_kwargs = mock_pro.return_value.dividend.call_args.kwargs
+            assert call_kwargs["ts_code"] == "600519.SH"
+            assert call_kwargs["limit"] == 3
 
     def test_dividend_history_empty(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.dividend.return_value = pd.DataFrame()
-                adp = TushareAdapter()
-                result = adp.get_dividend_history("600519")
-                assert result == []
+            mock_pro.return_value.dividend.return_value = pd.DataFrame()
+            adp = TushareAdapter()
+            result = adp.get_dividend_history("600519")
+            assert result == []
 
     def test_income_statement(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.income.return_value = pd.DataFrame({
+            mock_pro.return_value.income.return_value = pd.DataFrame(
+                {
                     "ts_code": ["600519.SH"],
                     "end_date": ["20240930"],
                     "total_revenue": [120000000000.0],
                     "n_income": [50000000000.0],
-                })
-                adp = TushareAdapter()
-                result = adp.get_income_statement("600519")
-                assert len(result) == 1
-                assert result[0]["n_income"] == 50000000000.0
+                }
+            )
+            adp = TushareAdapter()
+            result = adp.get_income_statement("600519")
+            assert len(result) == 1
+            assert result[0]["n_income"] == 50000000000.0
 
     def test_balance_sheet(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.balancesheet.return_value = pd.DataFrame({
+            mock_pro.return_value.balancesheet.return_value = pd.DataFrame(
+                {
                     "ts_code": ["600519.SH"],
                     "end_date": ["20240930"],
                     "total_assets": [200000000000.0],
-                })
-                adp = TushareAdapter()
-                result = adp.get_balance_sheet("600519")
-                assert len(result) == 1
-                assert result[0]["total_assets"] == 200000000000.0
+                }
+            )
+            adp = TushareAdapter()
+            result = adp.get_balance_sheet("600519")
+            assert len(result) == 1
+            assert result[0]["total_assets"] == 200000000000.0
 
     def test_cash_flow(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.cashflow.return_value = pd.DataFrame({
+            mock_pro.return_value.cashflow.return_value = pd.DataFrame(
+                {
                     "ts_code": ["600519.SH"],
                     "end_date": ["20240930"],
                     "n_cashflow_act": [30000000000.0],
-                })
-                adp = TushareAdapter()
-                result = adp.get_cash_flow("600519")
-                assert len(result) == 1
-                assert result[0]["n_cashflow_act"] == 30000000000.0
+                }
+            )
+            adp = TushareAdapter()
+            result = adp.get_cash_flow("600519")
+            assert len(result) == 1
+            assert result[0]["n_cashflow_act"] == 30000000000.0
 
     def test_list_all_stocks(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.stock_basic.return_value = pd.DataFrame({
+            mock_pro.return_value.stock_basic.return_value = pd.DataFrame(
+                {
                     "ts_code": ["600519.SH", "000001.SZ"],
                     "name": ["贵州茅台", "平安银行"],
                     "industry": ["白酒", "银行"],
-                })
-                adp = TushareAdapter()
-                result = adp.list_all_stocks()
-                assert len(result) == 2
-                assert result[0]["name"] == "贵州茅台"
+                }
+            )
+            adp = TushareAdapter()
+            result = adp.list_all_stocks()
+            assert len(result) == 2
+            assert result[0]["name"] == "贵州茅台"
 
     def test_list_all_stocks_with_status(self) -> None:
         with (
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.stock_basic.return_value = pd.DataFrame()
-                adp = TushareAdapter()
-                adp.list_all_stocks(list_status="D")
-                call_kwargs = mock_pro.return_value.stock_basic.call_args.kwargs
-                assert call_kwargs["list_status"] == "D"
+            mock_pro.return_value.stock_basic.return_value = pd.DataFrame()
+            adp = TushareAdapter()
+            adp.list_all_stocks(list_status="D")
+            call_kwargs = mock_pro.return_value.stock_basic.call_args.kwargs
+            assert call_kwargs["list_status"] == "D"
 
     def test_period_param_optional(self) -> None:
         """period 不传时不应出现在 kwargs（让 Tushare 走默认=最新期）。"""
@@ -663,8 +736,140 @@ class TestTushareFinancials:
             patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
             patch("tushare.pro_api") as mock_pro,
         ):
-                mock_pro.return_value.fina_indicator.return_value = pd.DataFrame()
-                adp = TushareAdapter()
-                adp.get_financial_indicator("600519")  # 不传 period
-                call_kwargs = mock_pro.return_value.fina_indicator.call_args.kwargs
-                assert "period" not in call_kwargs
+            mock_pro.return_value.fina_indicator.return_value = pd.DataFrame()
+            adp = TushareAdapter()
+            adp.get_financial_indicator("600519")  # 不传 period
+            call_kwargs = mock_pro.return_value.fina_indicator.call_args.kwargs
+            assert "period" not in call_kwargs
+
+
+# ---------- Golden fixture：基于 Tushare 官方文档样例数据 ----------
+# 这些 fixture 的字段名/单位直接来自 tushare.pro 文档的"数据样例"，
+# 防止 adapter 按自己的假设构造字段（历史上 moneyflow 字段名曾被捏造）
+
+
+class TestGoldenMoneyFlow:
+    """moneyflow 接口（tushare.pro/document/2?doc_id=170）。
+
+    文档约定：
+    - 四档只有 buy_xx_amount / sell_xx_amount，净流入 = buy - sell 自算
+    - 所有 amount 字段单位是**万元**
+    - net_mf_amount 是官方净流入额（万元），映射为主力净流入
+    """
+
+    @pytest.fixture
+    def adp(self) -> TushareAdapter:
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("TUSHARE_TOKEN", None)
+            return TushareAdapter()  # _bill_df_to_flow 不需要 token
+
+    def test_field_names_and_units(self, adp: TushareAdapter) -> None:
+        # 字段名与文档输出参数表逐一对应
+        df = pd.DataFrame(
+            {
+                "trade_date": ["20190315"],
+                "buy_sm_amount": [1150.17],
+                "sell_sm_amount": [1122.97],  # 小单（万元）
+                "buy_md_amount": [100.0],
+                "sell_md_amount": [50.0],  # 中单
+                "buy_lg_amount": [200.0],
+                "sell_lg_amount": [300.0],  # 大单
+                "buy_elg_amount": [1000.0],
+                "sell_elg_amount": [400.0],  # 特大单
+                "net_mf_amount": [5000.0],  # 净流入额（万元）
+            }
+        )
+        flows = adp._bill_df_to_flow(df, "000779")
+        assert len(flows) == 1
+        f = flows[0]
+        # 万元 → 元（×10000）
+        assert f.small_net.amount == 272000  # (1150.17 - 1122.97) * 10000
+        assert f.medium_net.amount == 500000  # (100 - 50) * 10000
+        assert f.large_net.amount == -1000000  # (200 - 300) * 10000
+        assert f.super_large_net.amount == 6000000  # (1000 - 400) * 10000
+        assert f.main_net.amount == 50000000  # 5000 * 10000
+        assert f.timestamp == datetime(2019, 3, 15)
+
+    def test_missing_buy_sell_fields_fall_back_to_zero(self, adp: TushareAdapter) -> None:
+        """缺字段时按 0 处理（与 efinance 的 _to_money 行为一致），不抛异常。"""
+        df = pd.DataFrame({"trade_date": ["20190315"], "net_mf_amount": [100.0]})
+        flows = adp._bill_df_to_flow(df, "000779")
+        assert flows[0].main_net.amount == 1000000
+        assert flows[0].small_net.amount == 0
+
+
+class TestGoldenDaily:
+    """daily 接口（tushare.pro/document/2?doc_id=27）。
+
+    文档约定：vol 单位是手，**amount 单位是千元**。
+    """
+
+    @pytest.fixture
+    def adp_with_token(self) -> TushareAdapter:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+            mock_pro.return_value.query.side_effect = Exception("not used")
+            return TushareAdapter()
+
+    def test_amount_is_thousand_yuan(self, adp_with_token: TushareAdapter) -> None:
+        """get_bars 的 turnover 必须从千元转成元。"""
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            # 文档样例行：000001.SZ 20180718
+            mock_pro_bar.return_value = pd.DataFrame(
+                {
+                    "trade_date": ["20180718"],
+                    "open": [8.75],
+                    "high": [8.85],
+                    "low": [8.69],
+                    "close": [8.70],
+                    "vol": [525152.77],
+                    "amount": [460697.377],  # 千元
+                    "pct_chg": [-0.23],
+                    "turnover_rate": [0.52],
+                }
+            )
+            bars = adp_with_token.get_bars("000001", BarInterval.D1, AdjustmentType.NONE)
+            assert len(bars) == 1
+            bar = bars[0]
+            assert bar.turnover.amount == 460697377  # 460697.377 千元 × 1000
+            assert bar.turnover_rate == Decimal("0.52")  # factors=["tor"] 并入的换手率
+            assert bar.change_pct == Decimal("-0.23")
+
+    def test_quote_amount_and_nan_market_cap(self, adp_with_token: TushareAdapter) -> None:
+        """get_quote：amount 千元→元；市值 NaN 时给 None 而不是 Money(0)。"""
+        adp = adp_with_token
+        adp._pro.daily_basic = MagicMock(
+            return_value=pd.DataFrame(
+                {
+                    "trade_date": ["20180718"],
+                    "turnover_rate": [0.52],
+                    "pe": [11.5],
+                    "total_mv": [float("nan")],  # NaN → None
+                    "circ_mv": [25000.0],  # 万元 → ×10000
+                }
+            )
+        )
+        adp._pro.daily = MagicMock(
+            return_value=pd.DataFrame(
+                {
+                    "trade_date": ["20180718"],
+                    "open": [8.75],
+                    "high": [8.85],
+                    "low": [8.69],
+                    "close": [8.70],
+                    "pre_close": [8.72],
+                    "change": [-0.02],
+                    "pct_chg": [-0.23],
+                    "vol": [525152.77],
+                    "amount": [460697.377],
+                }
+            )
+        )
+        q = adp.get_quote("000001")
+        assert q is not None
+        assert q.turnover.amount == 460697377
+        assert q.total_market_cap is None
+        assert q.circulating_market_cap is not None
+        assert q.circulating_market_cap.amount == 250000000  # 25000 万元 × 10000

--- a/tests/test_market_data/test_tushare_adapter.py
+++ b/tests/test_market_data/test_tushare_adapter.py
@@ -1,0 +1,670 @@
+"""TushareAdapter 单元测试（不依赖网络/token）。"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from mommy_chaogu.market_data.tushare_adapter import (
+    TushareAdapter,
+    apply_adjustment,
+    from_tushare_code,
+    to_tushare_code,
+)
+from mommy_chaogu.market_data.types import (
+    AdjustmentType,
+    Bar,
+    BarInterval,
+    MarketType,
+    Money,
+)
+
+# ---------- 代码转换 ----------
+
+
+class TestCodeConversion:
+    def test_internal_to_tushare_sh(self) -> None:
+        assert to_tushare_code("600519") == "600519.SH"
+
+    def test_internal_to_tushare_sz(self) -> None:
+        assert to_tushare_code("000001") == "000001.SZ"
+
+    def test_internal_to_tushare_with_explicit_market(self) -> None:
+        assert to_tushare_code("600519", MarketType.SH) == "600519.SH"
+        assert to_tushare_code("000001", MarketType.SZ) == "000001.SZ"
+
+    def test_already_tushare_format_unchanged(self) -> None:
+        assert to_tushare_code("600519.SH") == "600519.SH"
+        assert to_tushare_code("000001.SZ") == "000001.SZ"
+
+    def test_tushare_to_internal_with_market(self) -> None:
+        code, market = from_tushare_code("600519.SH")
+        assert code == "600519"
+        assert market == MarketType.SH
+
+    def test_tushare_to_internal_sz(self) -> None:
+        code, market = from_tushare_code("000001.SZ")
+        assert code == "000001"
+        assert market == MarketType.SZ
+
+    def test_roundtrip(self) -> None:
+        for original in ["600519", "000001", "300750"]:
+            ts_code = to_tushare_code(original)
+            recovered, _ = from_tushare_code(ts_code)
+            assert recovered == original
+
+
+# ---------- Adapter 基础行为 ----------
+
+
+class TestTushareAdapterInit:
+    def test_no_token_means_unavailable(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("TUSHARE_TOKEN", None)
+            adp = TushareAdapter()
+            assert adp.is_available is False
+
+    def test_explicit_empty_token_means_unavailable(self) -> None:
+        adp = TushareAdapter(token="")
+        assert adp.is_available is False
+
+    def test_token_from_env(self) -> None:
+        """token 从 TUSHARE_TOKEN 读：mock 掉 pro_api 避免真的去连。"""
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake_token_xxx"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                adp = TushareAdapter()
+                # 初始化过程中会调 tushare.set_token + tushare.pro_api
+                assert adp._token == "fake_token_xxx"
+                # pro_api 被调用过（fake_token 也走通）
+                mock_pro.assert_called_once()
+
+    def test_explicit_token_override(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "env_token"}),
+            patch("tushare.pro_api"),
+        ):
+                adp = TushareAdapter(token="explicit_token")
+                assert adp._token == "explicit_token"
+
+
+# ---------- 方法在没有 token 时的退化行为 ----------
+
+
+class TestTushareAdapterNoToken:
+    @pytest.fixture
+    def adp(self) -> TushareAdapter:
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("TUSHARE_TOKEN", None)
+            return TushareAdapter()
+
+    def test_get_quote_returns_none(self, adp: TushareAdapter) -> None:
+        assert adp.get_quote("600519") is None
+
+    def test_get_quotes_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.get_quotes(["600519", "000001"]) == []
+
+    def test_list_market_quotes_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.list_market_quotes() == []
+
+    def test_get_order_book_returns_none(self, adp: TushareAdapter) -> None:
+        assert adp.get_order_book("600519") is None
+
+    def test_get_bars_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.get_bars("600519", BarInterval.D1, AdjustmentType.FORWARD) == []
+
+    def test_get_ticks_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.get_ticks("600519") == []
+
+    def test_get_today_money_flow_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.get_today_money_flow("600519") == []
+
+    def test_get_history_money_flow_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.get_history_money_flow("600519", days=30) == []
+
+    def test_get_belonging_boards_returns_empty(self, adp: TushareAdapter) -> None:
+        assert adp.get_belonging_boards("600519") == []
+
+    def test_health_check_false(self, adp: TushareAdapter) -> None:
+        assert adp.health_check() is False
+
+
+# ---------- 方法在异常时的健壮性（mock token 但 API 失败）----------
+
+
+class TestTushareAdapterRobustness:
+    """有 token 但 API 抛错时，所有方法应该静默返回 None/空，不抛异常。"""
+
+    @pytest.fixture
+    def adp(self) -> TushareAdapter:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                # 让 pro_api 返回一个 mock，所有 query 抛异常
+                mock_pro.return_value.query.side_effect = Exception("API down")
+                return TushareAdapter()
+
+    def test_quote_handles_exception(self, adp: TushareAdapter) -> None:
+        assert adp.get_quote("600519") is None
+
+    def test_bars_handles_exception(self, adp: TushareAdapter) -> None:
+        assert adp.get_bars("600519", BarInterval.D1) == []
+
+    def test_money_flow_handles_exception(self, adp: TushareAdapter) -> None:
+        assert adp.get_history_money_flow("600519") == []
+
+    def test_health_check_handles_exception(self, adp: TushareAdapter) -> None:
+        assert adp.health_check() is False
+
+
+# ---------- 复权参数传递 ----------
+
+
+class TestTushareBarsAdjustment:
+    """验证 get_bars 正确传透复权参数给 pro_bar。
+
+    pro_bar 是从 tushare.pro.data_pro 导入的顶层函数，
+    我们 mock 它来检查传入的 adj 参数。
+    """
+
+    @pytest.fixture
+    def adp_with_token(self) -> TushareAdapter:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.query.side_effect = Exception("not used")
+                return TushareAdapter()
+
+    def test_forward_adjustment_passes_qfq(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            # 模拟 pro_bar 返回空 DataFrame
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame()
+
+            adp_with_token.get_bars("600519", BarInterval.D1, AdjustmentType.FORWARD)
+            assert mock_pro_bar.called
+            call_kwargs = mock_pro_bar.call_args.kwargs
+            assert call_kwargs.get("adj") == "qfq"
+
+    def test_backward_adjustment_passes_hfq(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame()
+
+            adp_with_token.get_bars("600519", BarInterval.D1, AdjustmentType.BACKWARD)
+            call_kwargs = mock_pro_bar.call_args.kwargs
+            assert call_kwargs.get("adj") == "hfq"
+
+    def test_no_adjustment_passes_none(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame()
+
+            adp_with_token.get_bars("600519", BarInterval.D1, AdjustmentType.NONE)
+            call_kwargs = mock_pro_bar.call_args.kwargs
+            assert call_kwargs.get("adj") is None
+
+    def test_d1_interval_passes_d_freq(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame()
+
+            adp_with_token.get_bars("600519", BarInterval.D1)
+            call_kwargs = mock_pro_bar.call_args.kwargs
+            assert call_kwargs.get("freq") == "D"
+
+    def test_m5_interval_passes_5min_freq(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame()
+
+            adp_with_token.get_bars("600519", BarInterval.M5)
+            call_kwargs = mock_pro_bar.call_args.kwargs
+            assert call_kwargs.get("freq") == "5min"
+
+    def test_pro_bar_exception_returns_empty(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            mock_pro_bar.side_effect = Exception("API timeout")
+            result = adp_with_token.get_bars("600519")
+            assert result == []
+
+
+# ---------- 复权工具函数 apply_adjustment ----------
+
+
+def _make_bars(prices: list[tuple[str, str, str, str, str]]) -> list[Bar]:
+    """生成测试用 K 线。prices: [(date, open, high, low, close), ...]"""
+    from datetime import datetime
+    from decimal import Decimal
+
+    return [
+        Bar(
+            code="600519",
+            name="贵州茅台",
+            interval=BarInterval.D1,
+            adjustment=AdjustmentType.NONE,
+            timestamp=datetime.strptime(d, "%Y-%m-%d"),
+            open=Decimal(o),
+            high=Decimal(h),
+            low=Decimal(low_p),
+            close=Decimal(c),
+            volume=1000,
+            turnover=Money(Decimal("1000000"), "CNY"),
+        )
+        for d, o, h, low_p, c in prices
+    ]
+
+
+class TestApplyAdjustment:
+    """验证前/后复权算法。
+
+    复权逻辑:
+        前复权:  adj = raw * (latest / current)  → 最新价不变
+        后复权:  adj = raw * (earliest / current)  → 最早价不变
+    """
+
+    def test_no_adjustment_returns_unchanged(self) -> None:
+        bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
+        result = apply_adjustment(bars, pd.DataFrame(), AdjustmentType.NONE)
+        assert result is bars or result == bars
+
+    def test_empty_bars_returns_empty(self) -> None:
+        result = apply_adjustment([], pd.DataFrame(), AdjustmentType.FORWARD)
+        assert result == []
+
+    def test_empty_factors_returns_bars_unchanged(self) -> None:
+        bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
+        result = apply_adjustment(bars, pd.DataFrame(), AdjustmentType.FORWARD)
+        assert len(result) == 1
+        assert result[0].close == bars[0].close
+
+    def test_forward_adjustment_keeps_latest_price(self) -> None:
+        """前复权：最新一天的收盘价应该等于原始收盘价。"""
+        # 3 天 K 线，价格不变
+        bars = _make_bars([
+            ("2024-01-02", "100", "105", "99", "102"),
+            ("2024-01-03", "102", "107", "101", "105"),
+            ("2024-01-04", "105", "110", "104", "108"),
+        ])
+        # 复权因子：1/2 = 1.0, 1/3 = 1.0, 1/4 = 1.0 (未除权)
+        factors = pd.DataFrame({
+            "trade_date": ["20240102", "20240103", "20240104"],
+            "adj_factor": [1.0, 1.0, 1.0],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        # 因子全 1.0，比例 = 1.0 / 1.0 = 1.0 → 价不变
+        assert result[2].close == bars[2].close  # 108
+        # 调整标记
+        assert result[2].adjustment == AdjustmentType.FORWARD
+
+    def test_forward_adjustment_handles_dividend(self) -> None:
+        """前复权：发生除权后，历史价会下调。"""
+        # 2 天 K 线：第一天除权前，第二天除权后
+        bars = _make_bars([
+            ("2024-01-02", "100", "105", "99", "102"),  # 除权前
+            ("2024-01-03", "98", "103", "97", "100"),    # 除权后
+        ])
+        # 复权因子：除权日因子变小（说明除权了）
+        # 2024-01-02: adj_factor = 2.0 (基准)
+        # 2024-01-03: adj_factor = 1.0 (除权后)
+        factors = pd.DataFrame({
+            "trade_date": ["20240102", "20240103"],
+            "adj_factor": [2.0, 1.0],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        # 前复权: ratio = latest_factor / current_factor
+        #   2024-01-02: ratio = 1.0 / 2.0 = 0.5  → 价减半
+        #   2024-01-03: ratio = 1.0 / 1.0 = 1.0  → 价不变
+        assert result[1].close == 100  # 最新价不变
+        assert result[0].close == 51    # 历史价减半 (102 * 0.5)
+        # OHLC 都要调整
+        assert result[0].open == 50    # 100 * 0.5
+        assert result[0].high == Decimal("52.5")  # 105 * 0.5
+
+    def test_backward_adjustment_keeps_earliest_price(self) -> None:
+        """后复权：最早一天的收盘价应该等于原始收盘价。"""
+        bars = _make_bars([
+            ("2024-01-02", "100", "105", "99", "102"),
+            ("2024-01-03", "98", "103", "97", "100"),
+        ])
+        factors = pd.DataFrame({
+            "trade_date": ["20240102", "20240103"],
+            "adj_factor": [2.0, 1.0],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.BACKWARD)
+        # 后复权: ratio = earliest_factor / current_factor
+        #   2024-01-02: ratio = 2.0 / 2.0 = 1.0  → 价不变
+        #   2024-01-03: ratio = 2.0 / 1.0 = 2.0  → 价倍增
+        assert result[0].close == 102  # 最早价不变
+        assert result[1].close == 200  # 100 * 2.0
+
+    def test_ohlc_all_adjusted_consistently(self) -> None:
+        """前复权后，OHLC 之间的相对关系（high >= close 等）保持。"""
+        bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
+        factors = pd.DataFrame({
+            "trade_date": ["20240102"],
+            "adj_factor": [0.5],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        assert result[0].high >= result[0].low
+        assert result[0].high >= result[0].close
+        assert result[0].low <= result[0].close
+        assert result[0].open >= result[0].low
+        assert result[0].open <= result[0].high
+
+    def test_volume_not_adjusted(self) -> None:
+        """成交量不复权（除权除息不影响量）。"""
+        bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
+        bars[0] = Bar(
+            code=bars[0].code, name=bars[0].name, interval=bars[0].interval,
+            adjustment=bars[0].adjustment, timestamp=bars[0].timestamp,
+            open=bars[0].open, high=bars[0].high, low=bars[0].low, close=bars[0].close,
+            volume=12345,  # 原始成交量
+            turnover=Money(Decimal("67890"), "CNY"),
+        )
+        factors = pd.DataFrame({
+            "trade_date": ["20240102"],
+            "adj_factor": [0.5],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        assert result[0].volume == 12345  # 成交量不变
+
+    def test_missing_factor_for_date_keeps_bar_unchanged(self) -> None:
+        """中间某个 bar 找不到因子：只跳过那根，其他正常调整。"""
+        bars = _make_bars([
+            ("2024-01-02", "100", "105", "99", "102"),
+            ("2024-01-03", "200", "210", "198", "204"),  # 没因子
+            ("2024-01-04", "98", "103", "97", "100"),
+        ])
+        # 给了 2024-01-02 和 2024-01-04 的因子，2024-01-03 缺失
+        factors = pd.DataFrame({
+            "trade_date": ["20240102", "20240104"],
+            "adj_factor": [2.0, 1.0],  # 最新因子 = 1.0
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        # 第 1 根：2024-01-02, factor=2.0, ratio = 1.0/2.0 = 0.5 → close 减半
+        assert result[0].close == 51  # 102 * 0.5
+        # 第 2 根：2024-01-03 找不到因子 → 跳过调整，保持原值
+        assert result[1].close == 204
+        # 第 3 根：2024-01-04, factor=1.0, ratio = 1.0/1.0 = 1.0 → 不变
+        assert result[2].close == 100
+
+    def test_missing_anchor_factor_returns_unchanged(self) -> None:
+        """如果最新/最旧那根 bar 找不到因子（锚点丢失），安全返回原始 bars。"""
+        # 缺 2024-01-04 的因子（最新 bar 锚点）
+        bars = _make_bars([
+            ("2024-01-02", "100", "105", "99", "102"),
+            ("2024-01-03", "98", "103", "97", "100"),
+            ("2024-01-04", "200", "210", "198", "204"),
+        ])
+        factors = pd.DataFrame({
+            "trade_date": ["20240102", "20240103"],  # 缺 2024-01-04
+            "adj_factor": [2.0, 1.0],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        # 锚点丢失 → 全部保持原值
+        assert result[0].close == 102
+        assert result[1].close == 100
+        assert result[2].close == 204
+
+    def test_accepts_timestamp_dates(self) -> None:
+        """trade_date 可以是 Timestamp / date，不一定必须是字符串。"""
+        bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
+        factors = pd.DataFrame({
+            "trade_date": [pd.Timestamp("2024-01-02")],
+            "adj_factor": [1.0],
+        })
+        result = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        assert result[0].close == 102  # factor=1.0 不变
+
+    def test_does_not_mutate_input_bars(self) -> None:
+        """重要：原 bars 列表不能被修改（Bar 是 frozen dataclass，自然满足）。"""
+        bars = _make_bars([("2024-01-02", "100", "105", "99", "102")])
+        original_close = bars[0].close
+        factors = pd.DataFrame({
+            "trade_date": ["20240102"],
+            "adj_factor": [0.5],
+        })
+        _ = apply_adjustment(bars, factors, AdjustmentType.FORWARD)
+        # 原 bar 不变
+        assert bars[0].close == original_close
+
+
+# ---------- fetch_and_adjust 便捷方法 ----------
+
+
+class TestFetchAndAdjust:
+    @pytest.fixture
+    def adp_with_token(self) -> TushareAdapter:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.query.side_effect = Exception("not used")
+                return TushareAdapter()
+
+    def test_returns_empty_when_no_token(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("TUSHARE_TOKEN", None)
+            adp = TushareAdapter()
+            result = adp.fetch_and_adjust("600519")
+            assert result == []
+
+    def test_returns_empty_when_get_bars_empty(self, adp_with_token: TushareAdapter) -> None:
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame()
+            result = adp_with_token.fetch_and_adjust("600519")
+            assert result == []
+
+    def test_applies_adjustment_on_success(self, adp_with_token: TushareAdapter) -> None:
+        """完整流程：拉 K 线 + 拉因子 + 应用复权。"""
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            # 模拟 pro_bar 返回 2 根 K 线
+            mock_pro_bar.return_value = pd.DataFrame({
+                "trade_date": ["20240102", "20240103"],
+                "open": [100.0, 98.0],
+                "high": [105.0, 103.0],
+                "low": [99.0, 97.0],
+                "close": [102.0, 100.0],
+                "vol": [1000, 1100],
+                "amount": [100000.0, 105000.0],
+            })
+            # mock adj_factor
+            adp_with_token._pro.adj_factor = MagicMock(return_value=pd.DataFrame({
+                "trade_date": ["20240102", "20240103"],
+                "adj_factor": [2.0, 1.0],
+            }))
+            result = adp_with_token.fetch_and_adjust(
+                "600519", mode=AdjustmentType.FORWARD
+            )
+            assert len(result) == 2
+            # 前复权：最新价（result[1]）= 100 不变；历史价（result[0]）减半
+            assert result[1].close == 100
+            assert result[0].close == 51  # 102 * 0.5
+
+    def test_returns_bars_when_adj_factor_fails(self, adp_with_token: TushareAdapter) -> None:
+        """adj_factor 失败时降级返回原始 K 线（不抛异常）。"""
+        with patch("tushare.pro.data_pro.pro_bar") as mock_pro_bar:
+            import pandas as pd
+            mock_pro_bar.return_value = pd.DataFrame({
+                "trade_date": ["20240102"],
+                "open": [100.0], "high": [105.0], "low": [99.0], "close": [102.0],
+                "vol": [1000], "amount": [100000.0],
+            })
+            adp_with_token._pro.adj_factor = MagicMock(side_effect=Exception("API down"))
+            result = adp_with_token.fetch_and_adjust("600519")
+            assert len(result) == 1
+            assert result[0].close == 102  # 原始价
+
+
+# ---------- 财务数据接口 ----------
+
+
+class TestTushareFinancials:
+    @pytest.fixture
+    def adp_no_token(self) -> TushareAdapter:
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("TUSHARE_TOKEN", None)
+            return TushareAdapter()
+
+    @pytest.fixture
+    def adp_with_token(self) -> TushareAdapter:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                return TushareAdapter(), mock_pro
+
+    def test_financial_indicator_no_token(self, adp_no_token: TushareAdapter) -> None:
+        assert adp_no_token.get_financial_indicator("600519") == []
+
+    def test_financial_indicator_with_token(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.fina_indicator.return_value = pd.DataFrame({
+                    "ts_code": ["600519.SH"],
+                    "end_date": ["20240930"],
+                    "roe": [25.5],
+                    "gross_profit_margin": [91.2],
+                })
+                adp = TushareAdapter()
+                result = adp.get_financial_indicator("600519", period="20240930")
+                assert len(result) == 1
+                assert result[0]["roe"] == 25.5
+                # 参数传递验证
+                call_kwargs = mock_pro.return_value.fina_indicator.call_args.kwargs
+                assert call_kwargs["ts_code"] == "600519.SH"
+                assert call_kwargs["period"] == "20240930"
+
+    def test_financial_indicator_handles_exception(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.fina_indicator.side_effect = Exception("API down")
+                adp = TushareAdapter()
+                result = adp.get_financial_indicator("600519")
+                assert result == []
+
+    def test_dividend_history(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.dividend.return_value = pd.DataFrame({
+                    "ts_code": ["600519.SH"] * 3,
+                    "end_date": ["20231231", "20221231", "20211231"],
+                    "cash_div": [30.88, 21.91, 19.29],
+                })
+                adp = TushareAdapter()
+                result = adp.get_dividend_history("600519", limit=3)
+                assert len(result) == 3
+                assert result[0]["cash_div"] == 30.88
+                call_kwargs = mock_pro.return_value.dividend.call_args.kwargs
+                assert call_kwargs["ts_code"] == "600519.SH"
+                assert call_kwargs["limit"] == 3
+
+    def test_dividend_history_empty(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.dividend.return_value = pd.DataFrame()
+                adp = TushareAdapter()
+                result = adp.get_dividend_history("600519")
+                assert result == []
+
+    def test_income_statement(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.income.return_value = pd.DataFrame({
+                    "ts_code": ["600519.SH"],
+                    "end_date": ["20240930"],
+                    "total_revenue": [120000000000.0],
+                    "n_income": [50000000000.0],
+                })
+                adp = TushareAdapter()
+                result = adp.get_income_statement("600519")
+                assert len(result) == 1
+                assert result[0]["n_income"] == 50000000000.0
+
+    def test_balance_sheet(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.balancesheet.return_value = pd.DataFrame({
+                    "ts_code": ["600519.SH"],
+                    "end_date": ["20240930"],
+                    "total_assets": [200000000000.0],
+                })
+                adp = TushareAdapter()
+                result = adp.get_balance_sheet("600519")
+                assert len(result) == 1
+                assert result[0]["total_assets"] == 200000000000.0
+
+    def test_cash_flow(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.cashflow.return_value = pd.DataFrame({
+                    "ts_code": ["600519.SH"],
+                    "end_date": ["20240930"],
+                    "n_cashflow_act": [30000000000.0],
+                })
+                adp = TushareAdapter()
+                result = adp.get_cash_flow("600519")
+                assert len(result) == 1
+                assert result[0]["n_cashflow_act"] == 30000000000.0
+
+    def test_list_all_stocks(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.stock_basic.return_value = pd.DataFrame({
+                    "ts_code": ["600519.SH", "000001.SZ"],
+                    "name": ["贵州茅台", "平安银行"],
+                    "industry": ["白酒", "银行"],
+                })
+                adp = TushareAdapter()
+                result = adp.list_all_stocks()
+                assert len(result) == 2
+                assert result[0]["name"] == "贵州茅台"
+
+    def test_list_all_stocks_with_status(self) -> None:
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.stock_basic.return_value = pd.DataFrame()
+                adp = TushareAdapter()
+                adp.list_all_stocks(list_status="D")
+                call_kwargs = mock_pro.return_value.stock_basic.call_args.kwargs
+                assert call_kwargs["list_status"] == "D"
+
+    def test_period_param_optional(self) -> None:
+        """period 不传时不应出现在 kwargs（让 Tushare 走默认=最新期）。"""
+        with (
+            patch.dict(os.environ, {"TUSHARE_TOKEN": "fake"}),
+            patch("tushare.pro_api") as mock_pro,
+        ):
+                mock_pro.return_value.fina_indicator.return_value = pd.DataFrame()
+                adp = TushareAdapter()
+                adp.get_financial_indicator("600519")  # 不传 period
+                call_kwargs = mock_pro.return_value.fina_indicator.call_args.kwargs
+                assert "period" not in call_kwargs

--- a/tests/test_market_data/test_utils.py
+++ b/tests/test_market_data/test_utils.py
@@ -1,0 +1,82 @@
+"""market_data.utils.detect_market 单元测试。"""
+
+from __future__ import annotations
+
+import pytest
+
+from mommy_chaogu.market_data.types import MarketType
+from mommy_chaogu.market_data.utils import detect_market
+
+
+class TestDetectMarket:
+    """A 股代码 → 市场映射。"""
+
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            # 沪 A 主板
+            ("600519", MarketType.SH),  # 贵州茅台
+            ("601318", MarketType.SH),  # 中国平安
+            ("603259", MarketType.SH),  # 药明康德
+            ("605358", MarketType.SH),  # 国光连锁
+            # 沪 A 科创板
+            ("688981", MarketType.SH),  # 中芯国际
+            # 深 A 主板
+            ("000001", MarketType.SZ),  # 平安银行
+            ("000002", MarketType.SZ),  # 万科 A
+            ("002594", MarketType.SZ),  # 比亚迪
+            # 深 A 创业板
+            ("300750", MarketType.SZ),  # 宁德时代
+            ("301236", MarketType.SZ),  # 软通动力
+            # 北交所（新）— 重点回归
+            ("830799", MarketType.BJ),  # 艾融软件
+            ("871245", MarketType.BJ),  # 北证 A 股
+            ("873001", MarketType.BJ),  # 北证 A 股
+            ("920123", MarketType.BJ),  # 北证 A 股
+            # 北交所（老三板）
+            ("400001", MarketType.BJ),
+            ("420001", MarketType.BJ),
+            ("430001", MarketType.BJ),
+            # 沪基金
+            ("510300", MarketType.SH),  # 沪深 300 ETF
+            ("511010", MarketType.SH),  # 国债 ETF
+        ],
+    )
+    def test_correct_market_mapping(self, code: str, expected: MarketType) -> None:
+        assert detect_market(code) == expected
+
+    @pytest.mark.parametrize(
+        "invalid_code",
+        [
+            "",
+            "abc",
+            "x",  # 1 字符
+            "xxxxx",  # 全字母
+            "60A519",  # 混合
+        ],
+    )
+    def test_invalid_code_returns_unknown(self, invalid_code: str) -> None:
+        assert detect_market(invalid_code) == MarketType.UNKNOWN
+
+    def test_bj_market_handled_correctly(self) -> None:
+        """回归测试：原 efinance/tushare adapter 漏了 83/87/88 开头的北交所股票。"""
+        # 这些都是真实的北交所股票
+        assert detect_market("830799") == MarketType.BJ  # 艾融软件
+        assert detect_market("871245") == MarketType.BJ
+        assert detect_market("873001") == MarketType.BJ
+
+    def test_chinext_recognized_as_sz(self) -> None:
+        """创业板 (30xxxx) 是深市，不是独立的 MarketType。"""
+        assert detect_market("300750") == MarketType.SZ
+        assert detect_market("301236") == MarketType.SZ
+
+    def test_star_market_recognized_as_sh(self) -> None:
+        """科创板 (688xxx) 是沪市。"""
+        assert detect_market("688981") == MarketType.SH
+
+    def test_does_not_crash_on_garbage(self) -> None:
+        """鲁棒性测试。"""
+        assert detect_market("60A519") == MarketType.UNKNOWN
+        # 非字符串类型（None 等）应安全返回 UNKNOWN 而不抛异常
+        assert detect_market(None) == MarketType.UNKNOWN  # type: ignore[arg-type]
+        assert detect_market(123) == MarketType.UNKNOWN  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,42 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "akracer"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/c6/f38feed5b961d73e1b4cb049fdb45338356e0f5b828b230c00d0e51f3137/akracer-0.0.14.tar.gz", hash = "sha256:e084c14bf6d9a02d5da375e3af1cba3d46f103aa1cf3a2010593b3e95bf1c29a", size = 10047643, upload-time = "2025-09-10T13:47:34.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/cb/1041355b14cd4b76ac082e8c676858f6eddb78f0ba37c59284adf36e5103/akracer-0.0.14-py3-none-any.whl", hash = "sha256:629eaccd0e1d18366804b797eb2692ed47bed0028f55b5a5af3cc277d521df04", size = 10076442, upload-time = "2025-09-10T13:47:29.061Z" },
+]
+
+[[package]]
+name = "akshare"
+version = "1.18.78"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "akracer", marker = "sys_platform == 'linux'" },
+    { name = "beautifulsoup4" },
+    { name = "curl-cffi" },
+    { name = "decorator" },
+    { name = "html5lib" },
+    { name = "jsonpath" },
+    { name = "lxml" },
+    { name = "mini-racer", marker = "sys_platform != 'linux'" },
+    { name = "openpyxl" },
+    { name = "pandas" },
+    { name = "py-mini-racer", marker = "sys_platform == 'linux'" },
+    { name = "requests" },
+    { name = "tabulate" },
+    { name = "tqdm" },
+    { name = "urllib3" },
+    { name = "xlrd" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/2b/33517e3584ee967a58f5fd1c8e1ce356c5ddbdf524317d592f9b0d82e3e5/akshare-1.18.78.tar.gz", hash = "sha256:d9a047c296b64282495e3d0fdda5db1aecf3cdf55fadcf07bcb40dc226440a92", size = 892675, upload-time = "2026-07-24T10:25:05.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/27/a35f9c895bc09c9fb60b5cf7cbc4d6ba607349caf75f0e1b6bd8c0730c70/akshare-1.18.78-py3-none-any.whl", hash = "sha256:a5853a6de7c119e856cd15e5daa93ad70003391ba5c5f5c487c53beb97026718", size = 1116544, upload-time = "2026-07-24T10:25:04.052Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -386,6 +422,39 @@ wheels = [
 ]
 
 [[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -420,6 +489,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/5c/2c2cf79cfd35d5315ed447f47adbda79ed57b775b3a91d3d00e5bed44f95/efinance-0.5.8.tar.gz", hash = "sha256:03af5b1d6bf8d38a521b6cab3aa2020c251d3a51bd905e8e69852a896710720a", size = 92845, upload-time = "2026-03-18T14:33:28.902Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/49/813c6f31cc969e30b263000dbdb9770c9435a6626d6d636c18c936703eeb/efinance-0.5.8-py3-none-any.whl", hash = "sha256:d8ebafedf64c865464392ef3ba8b5fadaf2b9770ac0f22d71913bc863138865c", size = 75088, upload-time = "2026-03-18T14:33:27.459Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -512,6 +590,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "html5lib"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/b6/b55c3f49042f1df3dcd422b7f224f939892ee94f22abcf503a9b7339eaf2/html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f", size = 272215, upload-time = "2020-06-22T23:32:38.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d", size = 112173, upload-time = "2020-06-22T23:32:36.781Z" },
 ]
 
 [[package]]
@@ -791,6 +882,86 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -917,6 +1088,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mini-racer"
+version = "0.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/b0/5b200bdf093433f1933f783fbc908c23349a1a575c28c81aff75b609c7c1/mini_racer-0.14.1.tar.gz", hash = "sha256:0df25889b7c4e753520324a1687d85e41f9f64984efa81963339ed400f004d49", size = 41771, upload-time = "2026-02-01T05:53:27.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/2c/5857ee4e1714db8956aa878dc90255557458c124f93163704e7de948be03/mini_racer-0.14.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:a401ecdf5f73d4714b76dc3a4c9b5780059cf4c59a5b64cff7497dc6c219d5a0", size = 19988474, upload-time = "2026-02-01T05:53:03.998Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/ecaad0c208b9d8bd8f2141f7fa5e520b66915945a2ed56c520524df75fcb/mini_racer-0.14.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:56cc6965a1665a50d8d613bc43aa83b4cec6b1f09acc69dc4c2845dacb201463", size = 18511166, upload-time = "2026-02-01T05:53:07.059Z" },
+    { url = "https://files.pythonhosted.org/packages/78/60/e0708ea8533e928f10f985be35af4c02dd2b61f4a7501dc88e8c927d85e5/mini_racer-0.14.1-py3-none-win_amd64.whl", hash = "sha256:4abd58c62c9955988dbc0cbf5a798914334fe570d2b192f8890bec20135ab6d1", size = 15515732, upload-time = "2026-02-01T05:53:22.276Z" },
+    { url = "https://files.pythonhosted.org/packages/99/fd/7fb43e269c44e5d44ef02fbd164fc11833d8293b47ddcd48e4fb1649f4d2/mini_racer-0.14.1-py3-none-win_arm64.whl", hash = "sha256:440bef1269655b1da94b550612b50669de9881c3d88b805c139f7f1b5ec8ae7b", size = 14829128, upload-time = "2026-02-01T05:53:24.983Z" },
+]
+
+[[package]]
 name = "mommy-chaogu"
 source = { editable = "." }
 dependencies = [
@@ -938,6 +1121,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "akshare" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
@@ -948,6 +1132,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "akshare", marker = "extra == 'dev'", specifier = ">=1.18" },
     { name = "efinance", specifier = ">=0.5.8" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
@@ -1104,6 +1289,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1198,6 +1395,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
+name = "py-mini-racer"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/97/a578b918b2e5923dd754cb60bb8b8aeffc85255ffb92566e3c65b148ff72/py_mini_racer-0.6.0.tar.gz", hash = "sha256:f71e36b643d947ba698c57cd9bd2232c83ca997b0802fc2f7f79582377040c11", size = 5994836, upload-time = "2021-04-22T07:58:35.993Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/a9/8ce0ca222ef04d602924a1e099be93f5435ca6f3294182a30574d4159ca2/py_mini_racer-0.6.0-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:42896c24968481dd953eeeb11de331f6870917811961c9b26ba09071e07180e2", size = 5416149, upload-time = "2021-04-22T07:58:25.615Z" },
 ]
 
 [[package]]
@@ -1744,6 +1950,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
 name = "textual"
 version = "8.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1975,6 +2190,15 @@ wheels = [
 ]
 
 [[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2017,4 +2241,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "xlrd"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/5a/377161c2d3538d1990d7af382c79f3b2372e880b65de21b01b1a2b78691e/xlrd-2.0.2.tar.gz", hash = "sha256:08b5e25de58f21ce71dc7db3b3b8106c1fa776f3024c54e45b45b374e89234c9", size = 100167, upload-time = "2025-06-14T08:46:39.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/62/c8d562e7766786ba6587d09c5a8ba9f718ed3fa8af7f4553e8f91c36f302/xlrd-2.0.2-py2.py3-none-any.whl", hash = "sha256:ea762c3d29f4cca48d82df517b6d89fbce4db3107f9d78713e48cd321d5c9aa9", size = 96555, upload-time = "2025-06-14T08:46:37.766Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bs4"
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/aa/4acaf814ff901145da37332e05bb510452ebed97bc9602695059dd46ef39/bs4-0.0.2.tar.gz", hash = "sha256:a48685c58f50fe127722417bae83fe6badf500d54b55f7e39ffe43b798653925", size = 698, upload-time = "2024-01-17T18:15:47.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl", hash = "sha256:abf8742c0805ef7f662dce4b51cca104cffe52b835238afc169142ab9b3fbccc", size = 1189, upload-time = "2024-01-17T18:15:48.613Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -1115,6 +1127,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "sqlite-vec" },
     { name = "textual" },
+    { name = "tushare" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
@@ -1150,6 +1163,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sqlite-vec", specifier = ">=0.1.9" },
     { name = "textual", specifier = ">=8.2.8" },
+    { name = "tushare", specifier = ">=1.4.29" },
     { name = "types-requests", marker = "extra == 'dev'" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
     { name = "websockets", specifier = ">=13" },
@@ -1844,6 +1858,59 @@ wheels = [
 ]
 
 [[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/25/e90998fe8e480eb43b966c09e835379887d427567ebd496563d3b1e16b19/simplejson-4.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:19040a17154dc03d289bab68d73ce0a6a0be01de30c584bbdd93490bead14b22", size = 112414, upload-time = "2026-04-24T19:23:06.084Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a0/abd4785f36c3400f1fbb21f517be39295a750a714f04b7ee175adf6ef580/simplejson-4.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a94ebaecdbaa80d9551a3ec6bf0c9302fc8b53ab6c1b2bfd498a1df4cb28158d", size = 91120, upload-time = "2026-04-24T19:23:07.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/78/fc060d2e3b13c6ec59288574b8efac64075e316b2afba4396a56b2422f78/simplejson-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:67341c95c0a168ab4a6d1e807e50463f1c8da932c3286d81e201266c427061fa", size = 91055, upload-time = "2026-04-24T19:23:09.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45ec18e337fec538b7e902d489505c450b2454653d1290f3f50385e6fd8aa607", size = 190297, upload-time = "2026-04-24T19:23:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1c/e4d0eab695be3eb21d0f46bce820752031f03e7113f9c80a9b3c73ee7157/simplejson-4.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:820c69a4710400e9b248d5670647d60be58824369282d3925e516b3ff1a7cd82", size = 187002, upload-time = "2026-04-24T19:23:12.982Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0e/7f5a59d29426b062d5928fb88b403c3f797129d53be7102f955dbe51aa44/simplejson-4.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e708d373a10e4378ef2d59f8361850c7150fd907ed49efe49bc5492160476d1", size = 195146, upload-time = "2026-04-24T19:23:14.517Z" },
+    { url = "https://files.pythonhosted.org/packages/78/18/9943db224dd4d5fa3c090c3e56a94c37b254338c83995ec5680285111c40/simplejson-4.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:980fc33353f81fd12d8c49d44f8c2760d1dc8192285e627c5180d141035b228a", size = 183931, upload-time = "2026-04-24T19:23:16.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/9a690da9a766161c06c627d805362cf159f1abe480969372b2897649b955/simplejson-4.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de2ed102fff88dacf543699f53ee3a533cc11539a39baa176b7e09dd783069d6", size = 192228, upload-time = "2026-04-24T19:23:18.33Z" },
+    { url = "https://files.pythonhosted.org/packages/05/88/bd8aad36b451ffb0e0a3f721d695a88befa6d1ac7d1e02ae788ca7ff4029/simplejson-4.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785ff8edc0e28bf773a32543a6bbed46351453c997b3f6709c744e3c2f7eabb", size = 187808, upload-time = "2026-04-24T19:23:21.165Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ee/14f91db0d1f481533b651dafbf8cd0da088d9817f7af30c68f7f19f9c847/simplejson-4.1.1-cp312-cp312-win32.whl", hash = "sha256:2e0d5ead6d14610467ec356ec1f6b5d8a56aa216abaad8d41c8b873b16cf313f", size = 88512, upload-time = "2026-04-24T19:23:22.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c4/90de06b2d8737c68c05ff9274113f854dbf6a5f28b7a955212111672cb57/simplejson-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:63a5451f557d6be48a231bae932458655c620902b868170b2f1c8afed496f6b4", size = 90748, upload-time = "2026-04-24T19:23:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a9/47b445eeb559c9593453a0648e0fd6d08e8adff64dd5e5ced66726da8a09/simplejson-4.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:dff52fc7af272e84fc21cc5a06c927c823ca6ae00af14f3b0d7707b42775ed98", size = 113160, upload-time = "2026-04-24T19:23:26.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/cb72db31523c164dea5dc55b02dad065a40c478856bc7534b279d2b51906/simplejson-4.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:971aed0647ad6e840a3943bec812fcda5f2d26a5497a4981d1fb49aa4f9a396c", size = 91521, upload-time = "2026-04-24T19:23:27.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e5/54cb7c50ad5fdc1e0a86b7df4b135c2cbd5c4623605aa94466659098e8da/simplejson-4.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:249e2e220aa6d9b9d936bde84eb7bf79d5b6c5a8273c6e411f8b1635a9073f2d", size = 91407, upload-time = "2026-04-24T19:23:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/21a3ede87f0bf82d6c7bcb90480d50a6490eb974c6ab20881188e440957c/simplejson-4.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e5cdd6a5d52299f345c15ab5678cc4249e24f383f361d986afbc3c7072a6b6b", size = 192451, upload-time = "2026-04-24T19:23:30.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/9903edd3102bf0b5984edfcb90c88612330996efa3b4fbf8a971d6e17839/simplejson-4.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642cec364e0676e2d5a73fa4d31d0c7c55886997caa2fde24e8292ca44d32728", size = 189015, upload-time = "2026-04-24T19:23:32.647Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cd/33230927a780e1398b857e3944abb914556994d252b1d765ae40d112cb25/simplejson-4.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:76fe296ca1df23d290033f10aaacf534fd1b3e3007e7f9ff8aa68b21413aaa78", size = 196658, upload-time = "2026-04-24T19:23:34.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/84/2c5a7444eb53e9a86d3738299bffddd9f53aeed799ded2f45368221fdb19/simplejson-4.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8f0ad25b7dc4e0fb23858355819f2e994f1a5badcdcde8737eac7921c2f1ed2a", size = 185967, upload-time = "2026-04-24T19:23:36.191Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/454378e06d059cd412a7ed5d87fb6d29fd5b60f13a4d89fc1f764ff434df/simplejson-4.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a59ebd0533f03fd06ff0c42ba0f02d93cbcdd7944922bf3b93911327a95b901f", size = 193940, upload-time = "2026-04-24T19:23:38.151Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d5/a15bf915f623a2c5a079d6e3be8256fdb8ef06f110669493a09b9d6933e0/simplejson-4.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bccbf4419676b517939852e5aeff2af6aee4dc046881c67a1581fa6f1cb01abd", size = 189795, upload-time = "2026-04-24T19:23:40.139Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c9/37212ae7dc4b607f0978c408e8633f05c810884e054c33113184c6c2c8a2/simplejson-4.1.1-cp313-cp313-win32.whl", hash = "sha256:6c845363eb5fd166fb7c72243da38f4fcfde666ede7fdf2cc6fd7762894626f7", size = 88773, upload-time = "2026-04-24T19:23:41.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c7a0a47883a9015b54c9d8a4b62f2aba17bd4335b1787b9b8a0fc2fa6d52/simplejson-4.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:104d8324c34f25b4b90800bc5fa363780cbc3d8496aef061cba7ce1af9162270", size = 90888, upload-time = "2026-04-24T19:23:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/4a118a6a92eb33bb08c8e2fe7ec85cb96f0673491bb2b829930831ee4fbe/simplejson-4.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:ed7473602b6625de793b6acba49aa949f144a475f538792067e4cf2fda2071f5", size = 110492, upload-time = "2026-04-24T19:23:44.957Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:225c9caa324c5b554d009fb9cac22aee7711e71bd96f487938c659af467e828e", size = 90152, upload-time = "2026-04-24T19:23:46.355Z" },
+    { url = "https://files.pythonhosted.org/packages/68/31/9a5432c433a7671107182cdc9a20ea78a70f99c4e5334aa54b6d4d0d79ed/simplejson-4.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:95407269340c7f22f09776ea7b717a52cf56cfcf119b5e45f66faa4a26445bea", size = 90115, upload-time = "2026-04-24T19:23:47.743Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/3635cdb13318cb0a328abaa69e2b91251caad39d6779aa308098f341f6cb/simplejson-4.1.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3851658d642c1184d2023f0e6c9ce44a21eb1629e74e7c84ef956b128841fe12", size = 184036, upload-time = "2026-04-24T19:23:49.472Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/149b6ec5393f6849d98c59cadba888b710a8ef4b805ab91e11a566960d40/simplejson-4.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:95a3bb0f78e85f4937f99092239f2011ce06f0f2d803df5c299cc05abbeae008", size = 180543, upload-time = "2026-04-24T19:23:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/a5d968d0b527a748b667e62bea94309ccbcb1e2b108e8f0cf8547efaa12b/simplejson-4.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbfdaa7c0603f75b7b14b211b7f2be44696d4e26833ad2d91d5c87bf5fb9a920", size = 188725, upload-time = "2026-04-24T19:23:52.995Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e3/6a8d11181d587ef00e2db9112357e6832111e56dd56b01b5c11758a1965d/simplejson-4.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e3c584071dced8c21b4689f0254303521daeb9b5bc1f4289755d71fa3cb0d3", size = 177492, upload-time = "2026-04-24T19:23:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/8b0eb8b06e8198cfbd1270487da163d0093df05cc4f557350cd65e2f7e79/simplejson-4.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:036a27bd0469b9d79557cbddb392969f876cd7f278cfbd0fba81534927a06575", size = 185281, upload-time = "2026-04-24T19:23:56.13Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5f/64990f07ec9e2cb1a814c674e2e21b5693207f74ac70eb72151b847ea4e6/simplejson-4.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b70bfd2f67f3351baba08aa3ae9233c83f21fd95ae5e6b3d0ecb8c647929112f", size = 181848, upload-time = "2026-04-24T19:23:57.92Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/bbc1bc0447f339f79f99ab8c37f7f037cb2f1f93af75d6a4d553096bb0c3/simplejson-4.1.1-cp314-cp314-win32.whl", hash = "sha256:37233c72ce88d06acb92747347742b3c07871eba6789f060c179c9302dde8efe", size = 88761, upload-time = "2026-04-24T19:23:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:cc0442dea71cd9cbf30a0b8b9929ab5aa6c02c0443a3d977351e6ec5bada4388", size = 91018, upload-time = "2026-04-24T19:24:00.85Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/4fa437f68ff72219bac3bf3d050de9c6265691f3a170e16954bd69d7cddd/simplejson-4.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:c996a4d38290c515af347740659ce095b425449c164a5c9fa3977caa6eff5dbe", size = 113919, upload-time = "2026-04-24T19:24:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/83/59de041d09eb4a9577f7015d7263c32095dfb7fde49717dff62145d89809/simplejson-4.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c65c763fb20d7ca113c1c14dce2fc04a0fc3a57aceff533d6fdac707c7bffb40", size = 91904, upload-time = "2026-04-24T19:24:03.812Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8e/46bb345d540f6eb31427d984a4e518cdb182d0621814fee4fee045e8815b/simplejson-4.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0da5c9f57206ee7ef280ff7f1d924937b0a64f9a271a5ef371a2ecdbebba7421", size = 91752, upload-time = "2026-04-24T19:24:05.622Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/1b2ce97f068835eb3d253c116a4df7a3f436b7bf2fb5ff1ba29287e8b0ec/simplejson-4.1.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ea3426e786425d10e9e82f8a6eda74a7d6eb10d99165ac3d0d3bbcb65c0ea343", size = 214021, upload-time = "2026-04-24T19:24:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/48/70/d93e556df6a0786298644a7c08304fcbeddc248325f23f38acbebeb21165/simplejson-4.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d75cea7a1025edd7e439b2966b3d977c45b5b899e2adaf422811b3ac702ed9fb", size = 213530, upload-time = "2026-04-24T19:24:09.289Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/c93bf305b9f00d7259e09e713d60e75bd0f7f53da970f716ab90491770e7/simplejson-4.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:63c2ada8e58f266491f19eed2eeeb7c25c6141e52f8f9e820f6bb94156cf8dbc", size = 218282, upload-time = "2026-04-24T19:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/20/a9b5d2e27ec44b069ee251bd55544fc76929a067107b1050001566ba86f3/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d1fffb56305c5b475ee746cf9e04f97423ba5aaacd292dc1255bd75b1d3b124b", size = 209249, upload-time = "2026-04-24T19:24:12.662Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e4/e06ee682ed5df67592181f5ecb062e35878967e27f5b6e087237d4548d95/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a6525ec733f43d0541206cffa64fd2aad5a7ae3eb76566aff49cd4db6382209a", size = 213963, upload-time = "2026-04-24T19:24:14.302Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/9f/1e160e4cd8cdbf062bf6a454cdf814dc7a48eb47e566fdb8f80ccb202605/simplejson-4.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:861e393260508efa64d8805a8e49c416c3484907e3f146ce966c69552b49b9a3", size = 210474, upload-time = "2026-04-24T19:24:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/cecd913df322df5bbe7ebb8ba39e0708e505a165553900da8a7761026d6f/simplejson-4.1.1-cp314-cp314t-win32.whl", hash = "sha256:d083b89d30948a751d3d97476c2ed91e4caaa24a1a1459bdbadb8876242c71fe", size = 91134, upload-time = "2026-04-24T19:24:17.635Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/f540dde99cc1d393bd062ab3b5735b777561a5d8f8a5f2e241164444d77a/simplejson-4.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4cbb299d0528ec0447fe366d8c9641860e28f997a62730690fef905f1f41046e", size = 94467, upload-time = "2026-04-24T19:24:19.109Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1985,6 +2052,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "tushare"
+version = "1.4.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bs4" },
+    { name = "lxml" },
+    { name = "pandas" },
+    { name = "requests" },
+    { name = "simplejson" },
+    { name = "tqdm" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/a4/5ce99585209410463e4b203d13c73d356c6ac92daea48af182932af7cb61/tushare-1.4.29.tar.gz", hash = "sha256:f578fb778868c0b744ac9173a837b695fd82e8d1b1e0d39c1f882b0e4fef7ecb", size = 128623, upload-time = "2026-03-25T06:33:44.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3e/d426a56e5feac9b0aaada1c6b0745ed03422d4a713295e0bbb44c8ea86fe/tushare-1.4.29-py3-none-any.whl", hash = "sha256:82554af953ea5ac3d8771d42330493181031c7e68dccce03a491c7356e9ba4b2", size = 142920, upload-time = "2026-03-25T06:33:43.111Z" },
 ]
 
 [[package]]
@@ -2196,6 +2281,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

本 PR 在行情数据层引入两个新数据源，并对 Tushare 适配器做了一轮对照官方文档的深度审核修复。

### 数据源集成

- **AKShare**（兜底字段补全源）：`stock_zh_a_spot_em` 补全 PE/PB/市值，K 线备用路径；仅在 akshare 已安装时启用（ADR 0002）
- **Tushare**（EOD 强项源，需 `TUSHARE_TOKEN`）：K 线/资金流/财务三表/分红/股票列表；海外 IP 友好（ADR 0003）

fallback 链最终顺序：**efinance → tencent → tushare → akshare**

### Tushare 审核修复（对照 tushare.pro 官方文档）

**P0 数据正确性**
- `moneyflow` 字段名改用官方 `buy/sell_{sm,md,lg,elg}_amount`（原 `net_xl_amount` 等字段不存在，四档净流入恒为 0），净流入 = buy−sell 自算，单位万元→元
- `daily.amount` 单位是**千元**，get_bars/get_quote 的 turnover 修正（原差 1000 倍）
- `apply_adjustment` 复权公式方向修正：`cur/latest`（前复权）、`cur/earliest`（后复权），与 pro_bar 的 qfq 源码对齐（adj_factor 随分红**递增**，原公式与测试 fixture 一起写反）
- 分钟线（M1~M60）显式不支持：stk_mins 需单独权限，且 pro_bar 在 adj≠None 时 drop 掉 trade_date 列，原实现静默返回空

**P1 链路**
- Tushare 排到腾讯之后：其 get_quote 是 EOD 合成快照（最早滞后 30 天），不能截胡真正的实时异构兜底
- `factors=["tor"]` 并入的换手率真正映射进 `Bar.turnover_rate`，不再白调 daily_basic
- get_quote 去掉未文档化的 `limit=1`；市值 NaN 返回 None 而非 Money(0)

**P2 杂项**
- 删除模块级 `warnings.filterwarnings("ignore")` 全局污染、死代码
- 可转债前缀（10~14）从 FUND 改标 `QuoteType.BOND`
- 模块 docstring 积分描述与官方对齐（moneyflow/adj_factor 需 2000 积分）

### 测试

- 复权 fixture 全部改为"因子递增"真实语义
- 新增 `TestGoldenMoneyFlow` / `TestGoldenDaily`：字段名与单位直接取自官方文档样例行，防止再按错误假设构造 mock 数据
- 分钟线改为"显式拒绝"断言

## 验收

- `pytest -m "not network"`：1602 passed
- `ruff check src tests`：通过
- `mypy --strict src`：0 错误（基线 11 个存量错误已顺手清理）

## 文档

- `docs/adr/0002-akshare-integration.md`
- `docs/adr/0003-tushare-integration.md`（新增：链顺序理由、单位约定、复权公式）