### PR TITLE
feat: add ma-suppression-monitor quant toolbox

### DIFF
--- a/quant/ma-suppression-monitor/README.md
+++ b/quant/ma-suppression-monitor/README.md
@@ -1,0 +1,100 @@
+# ma-suppression-monitor — 均线压制与趋势通道监控工具箱
+
+独立的量化监控工具箱：EMA 云带 / 枢轴通道 / 压制状态机 / 底部评分 / 双引擎编排。
+适用于 30 分钟到日线级别的股票与 ETF OHLC 数据，所有阈值用 ATR 归一化，
+跨品种、跨 regime 可比，无需人工调参。
+
+> **核心惯例**：信号在 bar 收盘确认，成交价为**下一根 bar 的开盘价**。全链路无未来函数。
+
+本目录是 mommy-chaogu 仓库内的**独立包**，与 `src/mommy_chaogu` 主程序完全解耦：
+不引用主包代码，主包也不依赖它。可单独安装、单独测试。
+
+## 安装
+
+```bash
+cd quant/ma-suppression-monitor
+pip install -e .          # 仅需 pandas>=2.0, numpy>=1.24
+```
+
+## 快速上手
+
+```python
+from ma_suppression_monitor import DualEngine, load_csv, score_events, forward_returns
+
+bars = load_csv("your_bars.csv")  # 任意含 time/open/high/low/close(/volume) 的 CSV
+eng = DualEngine()
+frame = eng.run(bars)  # 逐 bar 监控帧
+
+print(eng.readout(bars))  # 当前时刻面板读数 (dict)
+
+for e in eng.suppression_events_[-5:]:  # 压制确认事件
+    print(e.t_confirmed, f"第{e.count}次", f"深度{e.depth_atr:.2f}ATR")
+
+ev_idx = score_events(frame["score"], on=65, off=35)  # 底部评分事件
+fr = forward_returns(bars, ev_idx, [13, 26, 65])  # 无未来函数前向收益
+```
+
+完整示例：`python examples/run_on_soxx.py <csv路径>`
+
+## 模块地图
+
+| 文件 | 内容 |
+|---|---|
+| `bars.py` | 数据加载与规范化（OHLCV 约定，与数据源解耦） |
+| `indicators.py` | EMA 云带（55/89 斐波那契对）/ ATR / 枢轴点 / 回归通道 |
+| `regime.py` | **模块一** 趋势状态机 BULL/BEAR + 云带几何量（ATR 归一化） |
+| `channel.py` | **模块二** 枢轴通道（包含性约束 + 最大触碰拟合，复刻手绘通道） |
+| `suppression.py` | **模块三** 压制三阶段状态机：预判 ARMED / 监控 ENGAGED / 确认 CONFIRMED |
+| `bottom.py` | **模块四** 底部形态评分（四特征加权 0~100，含崩盘过滤器） |
+| `engine.py` | 双引擎编排：做空引擎 × 底部评分调制 + 单一口径警报 |
+| `backtest.py` | 无未来函数回测：前向收益 / B→S 成对交易 / 组合模拟 |
+| `macro_channel.py`（顶层） | 大尺度通道（4H/日线），最大回撤段锚定，独立于 `channel.py` |
+
+## 设计要点
+
+1. **一切阈值 ATR 归一化** — 跨品种可比、跨 regime 自适应、统计含义稳定。
+2. **EMA 用递推式（`adjust=False`）** — 与 TradingView `ta.ema` 完全一致（误差 < 0.001）。
+3. **趋势状态保持二元** — 纠缠区信息由连续变量 `cloud_width` 承载，下游规则更干净。
+4. **底部评分用固定仿射映射** — 样本内一次标定后不再动，样本外读数可直接比较。
+5. **防闪烁三件套** — 滞后缓冲 / 一次反弹只出一枪 / 压制计数（"事不过三"分组）。
+
+## 压制状态机
+
+```
+IDLE    --空头排列 且 价格逼近云带(≤1.5 ATR)--> ARMED
+ARMED   --探入触发区间 且 深度≥0.2 ATR-------> ENGAGED
+ARMED   --收盘站上云带上沿+缓冲--------------> IDLE   (预判失效)
+ENGAGED --收盘跌回云带下沿之下---------------> CONFIRMED (发信号)
+ENGAGED --收盘站上云带上沿-------------------> IDLE   (压制失败)
+CONFIRMED--价格离开云带>1.0 ATR-------------> ARMED  (重新武装, 计数+1)
+```
+
+## 警报优先级（单一口径，面板直接可读）
+
+```
+CROSS (金叉/死叉, ≤3 bar) > RALLY_FADE (压制确认区) >
+BOTTOM_WATCH (评分≥65) > TREND_LONG / FREE_FALL > —
+```
+
+## 测试
+
+```bash
+pip install pytest
+pytest tests/             # 合成数据冒烟测试, 不访问网络
+```
+
+## 配置
+
+全部默认值见 `engine.EngineConfig`（EMA 55/89、ATR 14、通道窗 60、
+BOTTOM_WATCH 65、底部特征权重 0.30/0.30/0.25/0.15 等），均可注入覆盖：
+
+```python
+from ma_suppression_monitor import DualEngine, EngineConfig, SuppressionConfig
+
+cfg = EngineConfig(
+    ema_fast=21,
+    ema_slow=55,
+    suppression=SuppressionConfig(arm_dist=2.0, min_depth=0.5),
+)
+eng = DualEngine(cfg)
+```

--- a/quant/ma-suppression-monitor/conftest.py
+++ b/quant/ma-suppression-monitor/conftest.py
@@ -1,0 +1,1 @@
+# 空 conftest: 将工具箱根目录加入 sys.path, 使 tests/ 能 import 顶层模块 macro_channel

--- a/quant/ma-suppression-monitor/examples/run_on_soxx.py
+++ b/quant/ma-suppression-monitor/examples/run_on_soxx.py
@@ -1,0 +1,53 @@
+"""
+示例: 在 SOXX 30min 数据上运行完整监控系统
+用法: python examples/run_on_soxx.py [csv_path]
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))  # 源码树内直接运行
+
+from ma_suppression_monitor import (
+    DualEngine,
+    baseline,
+    forward_returns,
+    load_csv,
+    score_events,
+)
+
+CSV = sys.argv[1] if len(sys.argv) > 1 else "data/SOXX_30min_bars_clean.csv"
+
+bars = load_csv(CSV)
+print(f"bars: {len(bars)}  {bars.index[0]} -> {bars.index[-1]}")
+
+# ---------- 1. 双引擎全量计算 ----------
+eng = DualEngine()
+frame = eng.run(bars)
+
+# ---------- 2. 当前监控读数 ----------
+readout = eng.readout(bars)
+print("\n=== 当前读数 ===")
+for k, v in readout.items():
+    print(f"  {k}: {v}")
+
+# ---------- 3. 压制状态机事件 (近窗口) ----------
+ev = eng.suppression_events_
+print(f"\n=== 压制事件: 共 {len(ev)} 次 ===")
+for e in ev[-5:]:
+    print(
+        f"  {e.t_confirmed}  第{e.count}次  深度{e.depth_atr:.2f}ATR  驻留{e.dwell_bars}b  收盘{e.confirm_close:.1f}"
+    )
+
+# ---------- 4. 底部评分事件回测 (无未来函数) ----------
+H = [13, 26, 65]
+ev_idx = score_events(frame["score"], on=65, off=35)
+fr = forward_returns(bars, ev_idx, H)
+bl = baseline(bars, H)
+print(f"\n=== 底部评分>65 事件: {len(ev_idx)} 次 ===")
+print(f"{'窗口':>6} {'事件均值%':>9} {'胜率%':>6} {'基准%':>7} {'超额%':>7}")
+for h in H:
+    s = fr[f"r{h}"].dropna()
+    print(
+        f"{h:>6} {s.mean():>9.2f} {100 * (s > 0).mean():>6.0f} {bl[h]:>7.2f} {s.mean() - bl[h]:>7.2f}"
+    )

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/__init__.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/__init__.py
@@ -1,0 +1,51 @@
+"""
+ma_suppression_monitor — 均线压制与趋势通道监控系统
+
+模块地图 (对应分析文档的四个模块 + 双引擎):
+  bars.py        数据加载与规范化
+  indicators.py  EMA 云带 / ATR / 枢轴点 / 回归通道
+  regime.py      模块一: 趋势状态机 + 云带几何量 (ATR 归一化)
+  channel.py     模块二: 枢轴通道 (包含性 + 最大触碰拟合)
+  suppression.py 模块三: 压制三阶段状态机 (预判/监控/确认)
+  bottom.py      模块四: 底部形态评分 (含崩盘过滤器)
+  engine.py      双引擎编排: 做空引擎 × 底部评分调制
+  backtest.py    无未来函数回测工具 (下一根 bar 开盘执行)
+"""
+
+from .backtest import baseline, forward_returns, portfolio_sim, score_events, signal_pairs
+from .bars import load_csv, resample_bars, validate
+from .bottom import BottomConfig, bottom_score
+from .channel import Channel, fit_channel
+from .engine import DualEngine, EngineConfig
+from .indicators import atr, ema, ema_cloud, linreg_channel, pivots
+from .regime import cloud_metrics, trend_regime
+from .suppression import SuppressionConfig, SuppressionEvent, run_suppression_engine
+
+__all__ = [
+    "BottomConfig",
+    "Channel",
+    "DualEngine",
+    "EngineConfig",
+    "SuppressionConfig",
+    "SuppressionEvent",
+    "atr",
+    "baseline",
+    "bottom_score",
+    "cloud_metrics",
+    "ema",
+    "ema_cloud",
+    "fit_channel",
+    "forward_returns",
+    "linreg_channel",
+    "load_csv",
+    "pivots",
+    "portfolio_sim",
+    "resample_bars",
+    "run_suppression_engine",
+    "score_events",
+    "signal_pairs",
+    "trend_regime",
+    "validate",
+]
+
+__version__ = "0.1.0"

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/backtest.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/backtest.py
@@ -1,0 +1,99 @@
+"""
+backtest.py — 无未来函数的回测工具
+
+执行惯例 (全库统一, 与用户约定一致):
+  信号在 bar t 收盘确认 → 成交价为 bar t+1 的 **开盘价**,
+  前向收益从该开盘价起算。跨 bar 跳空用旧仓位计价 (见 portfolio_sim)。
+
+提供三类评估:
+  1. forward_returns : 事件集的前向收益分布 (vs 无条件基准)
+  2. signal_pairs    : B→S 成对交易 (用户 B/S 信号的评估方法)
+  3. score_events    : 阈值穿越事件生成 (带上穿/下穿双阈值, 一次偏移只出一枪)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def forward_returns(bars: pd.DataFrame, event_idx: list[int], horizons: list[int]) -> pd.DataFrame:
+    """事件前向收益: 从 t+1 开盘到 t+1+h 收盘 (百分比)。"""
+    o = np.log(bars["open"].values)
+    c = np.log(bars["close"].values)
+    rows = []
+    for t in event_idx:
+        if t + 1 >= len(bars):
+            continue
+        entry = o[t + 1]
+        row = {"time": bars.index[t]}
+        for h in horizons:
+            row[f"r{h}"] = (c[t + 1 + h] - entry) * 100 if t + 1 + h < len(bars) else np.nan
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def baseline(bars: pd.DataFrame, horizons: list[int], step: int = 7) -> dict:
+    """无条件基准: 每隔 step 根取样一次的前向收益均值。"""
+    idx = list(range(0, len(bars) - max(horizons) - 2, step))
+    fr = forward_returns(bars, idx, horizons)
+    return {h: fr[f"r{h}"].mean() for h in horizons}
+
+
+def score_events(score: pd.Series, on: float = 65, off: float = 35) -> list[int]:
+    """评分上穿 on 触发, 下穿 off 重置 (一次偏移只出一枪)。"""
+    events, state = [], 0
+    v = score.values
+    for i, s in enumerate(v):
+        if state == 0 and s > on:
+            events.append(i)
+            state = 1
+        elif state == 1 and s < off:
+            state = 0
+    return events
+
+
+def signal_pairs(bars: pd.DataFrame, buy_flags: pd.Series, sell_flags: pd.Series) -> pd.DataFrame:
+    """
+    B→S 成对交易: B 出现 → 下一根开盘买入; 之后第一个 S → 下一根开盘卖出。
+    连续 B 不重复加仓。
+    """
+    b_idx = np.where(buy_flags.values)[0]
+    s_idx = np.where(sell_flags.values)[0]
+    events = sorted([(i, "B") for i in b_idx] + [(i, "S") for i in s_idx])
+    trades, pos = [], None
+    for t, kind in events:
+        if kind == "B" and pos is None and t + 1 < len(bars):
+            pos = t
+        elif kind == "S" and pos is not None and t + 1 < len(bars):
+            ret = bars["open"].iloc[t + 1] / bars["open"].iloc[pos + 1] - 1
+            trades.append(
+                {
+                    "entry_t": bars.index[pos + 1],
+                    "exit_t": bars.index[t + 1],
+                    "ret": ret,
+                    "bars_held": t - pos,
+                }
+            )
+            pos = None
+    return pd.DataFrame(trades)
+
+
+def portfolio_sim(bars: pd.DataFrame, target_pos: pd.Series) -> pd.Series:
+    """
+    逐 bar 组合模拟 (log 收益序列):
+      仓位变化在信号 bar 的下一根 bar 开盘生效;
+      跨 bar 跳空用旧仓位, bar 内用新仓位 —— 严格模拟实盘执行顺序。
+    target_pos: 每根 bar 收盘时的目标仓位 (-1/0/1)。
+    """
+    lo = np.log(bars["open"].values)
+    lc = np.log(bars["close"].values)
+    gap = lo - np.roll(lc, 1)
+    gap[0] = 0.0
+    intra = lc - lo
+    s = target_pos.values.astype(float)
+    s_prev1 = np.roll(s, 1)
+    s_prev2 = np.roll(s, 2)
+    s_prev1[0] = s_prev2[0] = s_prev2[1] = 0.0
+    port = s_prev2 * gap + s_prev1 * intra
+    return pd.Series(port, index=bars.index, name="strategy_logret")

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/bars.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/bars.py
@@ -1,0 +1,56 @@
+"""
+bars.py — 数据加载与规范化
+
+所有模块统一在一个简单的 Bar DataFrame 约定上工作：
+    index: DatetimeIndex (tz-aware 建议, 但不强制)
+    columns: open, high, low, close, volume (volume 可选, 缺省补 0)
+
+设计说明
+--------
+刻意不引入自定义 Bar 类——指标计算全部向量化, 直接用 pandas。
+库的输入只需要 OHLC(V), 与数据源解耦 (CSV / Yahoo / BATS 导出均可)。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+REQUIRED = ["open", "high", "low", "close"]
+
+
+def load_csv(
+    path: str, time_col: str = "time", tz: str | None = "America/New_York"
+) -> pd.DataFrame:
+    """加载 OHLC CSV。列名大小写不敏感, time 列解析为 DatetimeIndex。"""
+    df = pd.read_csv(path)
+    df.columns = [c.strip() for c in df.columns]
+    lower = {c.lower(): c for c in df.columns}
+    out = pd.DataFrame()
+    for col in [*REQUIRED, "volume"]:
+        if col in lower:
+            out[col] = pd.to_numeric(df[lower[col]], errors="coerce")
+    if "volume" not in out:
+        out["volume"] = 0.0
+    t = pd.to_datetime(df[time_col], utc=True)
+    if tz:
+        t = t.dt.tz_convert(tz)
+    out.index = t
+    out.index.name = "time"
+    return validate(out)
+
+
+def validate(df: pd.DataFrame) -> pd.DataFrame:
+    """丢缺失、排序、去重, 返回干净 bars。"""
+    missing = [c for c in REQUIRED if c not in df.columns]
+    if missing:
+        raise ValueError(f"missing columns: {missing}")
+    df = df.dropna(subset=REQUIRED).sort_index()
+    df = df[~df.index.duplicated(keep="last")]
+    return df
+
+
+def resample_bars(df: pd.DataFrame, rule: str) -> pd.DataFrame:
+    """聚合到更粗周期 (如 30min→2h)。rule 用 pandas offset 别名。"""
+    agg = {"open": "first", "high": "max", "low": "min", "close": "last", "volume": "sum"}
+    out = df.resample(rule).agg({k: v for k, v in agg.items() if k in df.columns})
+    return validate(out)

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/bottom.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/bottom.py
@@ -1,0 +1,109 @@
+"""
+bottom.py — 底部形态评分 (模块四)
+
+把交易员的底部经验形式化为四个 ATR 归一化特征, 加权成 0~100 的评分:
+
+  特征                    权重   含义                              真底部均值*
+  ─────────────────────────────────────────────────────────────────
+  均线走平度 slope_slow    30%   EMA89 的 26 根斜率 (越平越好)      -1.98 ATR
+  底底高结构 higher_lows   30%   最近 3 个 pivot 低点抬升步数        0.73 / 2
+  价格贴线度 cloud_dist    25%   价格相对云带下沿 (收复云带最好)     +0.95 ATR
+  云带收敛度 cloud_width   15%   EMA89-55 开口 (收口好)             1.14 ATR
+
+  * 真底部 = SOXX 2023-2026 年 42 个主要波段低点中,
+    随后 130 根 bar 反弹 ≥10% 且不再破位的 12 个。
+
+两条硬经验, 都来自回测的失败模式分析:
+  1. 崩盘过滤器: 价格在云带下 > crash_dist ATR (自由落体) 时, 评分封顶 49。
+     "跌得慢了 ≠ 不跌了" —— 2026-06-09 和 2026-07-14 两次假信号同源于此。
+  2. 评分只在空头排列有意义 (多头里的"走平"是另一回事),
+     引擎层负责按 regime 门控, 本模块如实输出原始分。
+
+特征→分数用**固定仿射映射**而不是滚动分位数:
+  分位数映射在极端行情里会失真 (2026-06 崩盘中"相对走平"被高估),
+  固定映射用样本内 (2023-2025) 的真底部分布一次标定, 之后不再动,
+  保证了 2026 样本外读数与样本内可直接比较 (OOS 胜率反而更高: 75% vs 53%)。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .indicators import pivots
+
+
+@dataclass
+class BottomConfig:
+    w_slope: float = 0.30
+    w_hl: float = 0.30
+    w_dist: float = 0.25
+    w_gap: float = 0.15
+    # 仿射映射端点 (样本内标定)
+    slope_lo: float = -4.0  # ATR/26bars, ≤此值 → 0 分
+    slope_hi: float = 0.0  # ≥此值 → 100 分
+    dist_lo: float = -2.0  # ATR
+    dist_hi: float = 1.0
+    gap_narrow: float = 0.5  # ATR, ≤ → 100 分
+    gap_wide: float = 3.0  # ≥ → 0 分
+    crash_dist: float = 2.0  # 崩盘过滤器阈值 (ATR)
+    pivot_order: int = 6
+    pivot_lookback: int = 120
+
+
+def _lin(x: float, x0: float, x1: float) -> float:
+    return float(np.clip((x - x0) / (x1 - x0) * 100, 0, 100))
+
+
+def bottom_score(
+    bars: pd.DataFrame,
+    metrics: pd.DataFrame,
+    cfg: BottomConfig | None = None,
+) -> pd.DataFrame:
+    """
+    输入 bars + regime.cloud_metrics 输出, 返回逐 bar 的评分与分量。
+    列: score, s_slope, s_hl, s_dist, s_gap, crash_blocked
+    """
+    cfg = cfg or BottomConfig()
+    slope = metrics["slope_slow"]
+    dist = metrics["cloud_dist"]
+    gap = metrics["cloud_width"]
+
+    # higher-lows: 最近 lookback 根内, 最近 3 个 pivot 低点的抬升步数 ×50
+    lows = bars["low"]
+    hl = pd.Series(0.0, index=bars.index)
+    lo_idx = pivots(lows, cfg.pivot_order, "low")
+    pos_of = {int(v): k for k, v in enumerate(lo_idx)}
+    for i in range(len(bars)):
+        j = i
+        while j >= 0 and j not in pos_of:
+            j -= 1
+        if j < 0:
+            continue
+        k = pos_of[j]
+        if k >= 2 and i - lo_idx[k - 2] <= cfg.pivot_lookback:
+            v = lows.values[lo_idx[k - 2 : k + 1]]
+            hl.iloc[i] = (50.0 if v[2] > v[1] else 0.0) + (50.0 if v[1] > v[0] else 0.0)
+
+    s_slope = slope.apply(lambda x: _lin(x, cfg.slope_lo, cfg.slope_hi) if pd.notna(x) else 0.0)
+    s_dist = dist.apply(lambda x: _lin(x, cfg.dist_lo, cfg.dist_hi) if pd.notna(x) else 0.0)
+    s_gap = gap.apply(
+        lambda x: 100.0 - _lin(x, cfg.gap_narrow, cfg.gap_wide) if pd.notna(x) else 0.0
+    )
+
+    raw = cfg.w_slope * s_slope + cfg.w_hl * hl + cfg.w_dist * s_dist + cfg.w_gap * s_gap
+    crash_blocked = dist < -cfg.crash_dist
+    score = raw.where(~crash_blocked, raw.clip(upper=49.0)).clip(0, 100)
+
+    return pd.DataFrame(
+        {
+            "score": score.round(1),
+            "s_slope": s_slope.round(1),
+            "s_hl": hl,
+            "s_dist": s_dist.round(1),
+            "s_gap": s_gap.round(1),
+            "crash_blocked": crash_blocked,
+        }
+    )

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/channel.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/channel.py
@@ -1,0 +1,122 @@
+"""
+channel.py — 枢轴通道识别 (模块二)
+
+复刻交易者手绘通道的算法, 已在 SOXX 2026 年 6-7 月下降通道上验证
+(自动上轨与手绘线误差 < 1.5%, 5 个触点全部命中)。
+
+四步:
+  1. 找摆动高/低点 (pivots, order 默认 12);
+  2. 以最高点 pivot 为锚 (通道起点 = 趋势顶点, 与手绘习惯一致);
+  3. 枚举高点对生成候选上轨, 硬约束 "之后所有高点不得突破 (容差 0.5%)",
+     在满足包含性 (containment) 的候选中选触点最多者;
+  4. 下轨 = 同斜率, 平移到最深的 pivot 低点。
+
+为什么用"包含性+最大触碰"而不是最小二乘:
+  最小二乘会被毛刺 (如 2026-06-30 的 644.9 次高点) 拉偏斜率;
+  手绘通道的本质是 "包络所有价格的极值线", 枚举+包含性直接编码了这个意图。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from .indicators import pivots
+
+
+@dataclass
+class Channel:
+    slope: float  # $/bar
+    upper_int: float  # 上轨截距 (x = bar 序号)
+    lower_int: float
+    anchor: int  # 锚点 bar 位置
+    touches: int  # 上轨触点数
+    ok: bool
+
+    def upper(self, n: int) -> np.ndarray:
+        return self.slope * np.arange(n) + self.upper_int
+
+    def lower(self, n: int) -> np.ndarray:
+        return self.slope * np.arange(n) + self.lower_int
+
+    def position(self, close: float, i: int) -> float:
+        """价格在当前通道中的位置 0~100。"""
+        u, lo_line = self.slope * i + self.upper_int, self.slope * i + self.lower_int
+        return float(np.clip((close - lo_line) / (u - lo_line) * 100, -50, 150))
+
+
+def fit_channel(
+    bars: pd.DataFrame,
+    order: int = 12,
+    contain_tol: float = 0.005,
+    touch_tol: float = 0.006,
+    direction: str = "down",
+) -> Channel:
+    """
+    拟合下降 (direction='down') 或上升 ('up') 通道。
+    找不到满足约束的通道时返回 ok=False (通道不存在也是有效信息)。
+    """
+    h, lo_vals = bars["high"].values, bars["low"].values
+    n = len(bars)
+    hi = pivots(bars["high"], order, "high")
+    lo = pivots(bars["low"], order, "low")
+    if direction == "down":
+        if len(hi) < 3:
+            return Channel(0, 0, 0, 0, 0, False)
+        anchor = hi[np.argmax(h[hi])]
+        piv_line, piv_base = hi[hi > anchor], lo[lo > anchor]
+        rail_vals, base_vals = h, lo_vals
+
+        def slope_ok(m: float) -> bool:
+            return m < 0
+    else:
+        if len(lo) < 3:
+            return Channel(0, 0, 0, 0, 0, False)
+        anchor = lo[np.argmin(lo_vals[lo])]
+        piv_line, piv_base = lo[lo > anchor], hi[hi > anchor]
+        rail_vals, base_vals = lo_vals, h
+
+        def slope_ok(m: float) -> bool:
+            return m > 0
+
+    if len(piv_line) < 2 or len(piv_base) < 1:
+        return Channel(0, 0, 0, anchor, 0, False)
+
+    # 枚举枢轴对 → 候选轨线, 包含性约束 + 最大触点
+    best = None
+    pts = [(int(i), float(rail_vals[i])) for i in piv_line]
+    ref_line = h if direction == "down" else lo_vals
+    for a in range(len(pts)):
+        for c in range(a + 1, len(pts)):
+            (x1, y1), (x2, y2) = pts[a], pts[c]
+            m = (y2 - y1) / (x2 - x1)
+            if not slope_ok(m):
+                continue
+            b0 = y1 - m * x1
+            line = m * np.arange(n) + b0
+            after = ref_line[x1:]
+            seg = line[x1:]
+            violated = (
+                (after > seg * (1 + contain_tol)).any()
+                if direction == "down"
+                else (after < seg * (1 - contain_tol)).any()
+            )
+            if violated:
+                continue
+            touches = sum(
+                1 for i in piv_line if abs(rail_vals[i] - line[i]) / abs(line[i]) < touch_tol
+            )
+            if best is None or touches > best[0]:
+                best = (touches, m, b0)
+    if best is None:
+        return Channel(0, 0, 0, anchor, 0, False)
+
+    touches, m, b0 = best
+    # 平行对轨: 过最深的对侧枢轴
+    offs = [base_vals[i] - m * int(i) for i in piv_base]
+    b1 = min(offs) if direction == "down" else max(offs)
+    return Channel(
+        slope=m, upper_int=b0, lower_int=b1, anchor=int(anchor), touches=touches, ok=True
+    )

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/engine.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/engine.py
@@ -1,0 +1,127 @@
+"""
+engine.py — 双引擎架构 (编排层)
+
+做空引擎 (suppression.py) 与底部评分 (bottom.py) 不是两个并列信号,
+而是调制关系: 底部评分回答 "下跌趋势是不是快完了",
+它降权/挂起做空引擎, 并在指标沉默期 (死叉后~金叉前) 预武装做多侧。
+
+    底部评分 < 25  : 做空引擎正常工作
+    25 ~ 50        : S 信号降仓 (半仓), 确认判据收紧
+    > 50           : 做空引擎挂起 (不开新空), BOTTOM_WATCH 点亮
+    BOTTOM_WATCH 中, 价格收复云带 + 金叉 → LONG_ARMED (做多预武装)
+    BOTTOM_WATCH 中, 跌破最近 pivot 低点 → 底部证伪, 评分作废
+
+Alert 优先级 (单一口径输出, 面板直接可读):
+    CROSS (金叉/死叉, 3 bar 内) > RALLY_FADE (压制确认区) >
+    BOTTOM_WATCH (评分≥65) > TREND_LONG / FREE_FALL > —
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+from .bottom import BottomConfig, bottom_score
+from .channel import Channel, fit_channel
+from .indicators import atr, ema_cloud, linreg_channel
+from .regime import cloud_metrics, trend_regime
+from .suppression import SuppressionConfig, run_suppression_engine
+
+
+@dataclass
+class EngineConfig:
+    ema_fast: int = 55
+    ema_slow: int = 89
+    atr_n: int = 14
+    chan_window: int = 60
+    bottom_watch: float = 65.0
+    bottom_caution: float = 50.0
+    rally_fade_pos: float = 75.0
+    suppression: SuppressionConfig = field(default_factory=SuppressionConfig)
+    bottom: BottomConfig = field(default_factory=BottomConfig)
+
+
+class DualEngine:
+    """一次性计算全部模块, 输出逐 bar 的监控帧 + 当前读数。"""
+
+    def __init__(self, cfg: EngineConfig | None = None):
+        self.cfg = cfg or EngineConfig()
+
+    def run(self, bars: pd.DataFrame) -> pd.DataFrame:
+        c = self.cfg
+        cloud = ema_cloud(bars["close"], c.ema_fast, c.ema_slow)
+        regime = trend_regime(cloud)
+        atr_ = atr(bars, c.atr_n)
+        metrics = cloud_metrics(bars, regime, atr_)
+        chan = linreg_channel(bars["close"], c.chan_window)
+        bscore = bottom_score(bars, metrics, c.bottom)
+        sup = run_suppression_engine(bars, regime, atr_, c.suppression, chan["pos"])
+
+        frame = pd.concat(
+            [
+                regime[["regime", "cross_age"]],
+                metrics,
+                chan[["pos", "slope"]].rename(columns={"pos": "chan_pos", "slope": "chan_slope"}),
+                bscore,
+                sup.states,
+            ],
+            axis=1,
+        )
+        frame["tests_26"] = (frame["suppression_state"] == "ENGAGED").rolling(26).sum().fillna(0)
+        # 引擎门控
+        frame["engine"] = "SHORT_ACTIVE"
+        frame.loc[frame["score"] >= c.bottom_caution, "engine"] = "SHORT_REDUCED"
+        frame.loc[frame["score"] >= c.bottom_watch, "engine"] = "BOTTOM_WATCH"
+        frame.loc[frame["regime"] == "BULL", "engine"] = "LONG_SIDE"
+
+        # 单一口径警报
+        alert = pd.Series("—", index=bars.index)
+        fade = (
+            (frame["regime"] == "BEAR")
+            & (frame["chan_pos"] >= c.rally_fade_pos)
+            & (frame["tests_26"] > 0)
+        )
+        alert[fade] = "RALLY_FADE"
+        watch = (frame["regime"] == "BEAR") & (frame["score"] >= c.bottom_watch)
+        alert[(alert == "—") & watch] = "BOTTOM_WATCH"
+        alert[(alert == "—") & (frame["regime"] == "BULL") & (frame["cloud_dist"] > 0)] = (
+            "TREND_LONG"
+        )
+        alert[(alert == "—") & (frame["cloud_dist"] < -1.5)] = "FREE_FALL"
+        new_cross = frame["cross_age"] <= 3
+        alert[new_cross] = frame["regime"][new_cross].map({"BULL": "GOLDEN_X", "BEAR": "DEATH_X"})
+        frame["alert"] = alert
+
+        self.frame_ = frame
+        self.suppression_events_ = sup.events
+        return frame
+
+    def readout(self, bars: pd.DataFrame, use_pivot_channel: bool = True) -> dict:
+        """当前时刻的监控面板读数 (dict)。"""
+        frame = self.frame_
+        i = len(frame) - 1
+        row = frame.iloc[-1]
+        out = {
+            "time": str(frame.index[-1]),
+            "close": float(bars["close"].iloc[-1]),
+            "regime": row["regime"],
+            "cross_age": int(row["cross_age"]),
+            "slope_slow_atr": round(float(row["slope_slow"]), 2),
+            "cloud_dist_atr": round(float(row["cloud_dist"]), 2),
+            "cloud_width_atr": round(float(row["cloud_width"]), 2),
+            "chan_pos": round(float(row["chan_pos"]), 1),
+            "bottom_score": float(row["score"]),
+            "engine": row["engine"],
+            "alert": row["alert"],
+            "suppression_events_total": len(self.suppression_events_),
+        }
+        if use_pivot_channel:
+            ch: Channel = fit_channel(bars, direction="down" if row["regime"] == "BEAR" else "up")
+            if ch.ok:
+                out["pivot_channel"] = {
+                    "slope_per_bar": round(ch.slope, 3),
+                    "touches": ch.touches,
+                    "position": round(ch.position(float(bars["close"].iloc[-1]), i), 1),
+                }
+        return out

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/indicators.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/indicators.py
@@ -1,0 +1,102 @@
+"""
+indicators.py — 指标层
+
+库的指标选择有一条主线: **一切阈值用 ATR 归一化**。
+
+为什么用 ATR 而不是固定点数/百分比:
+  1. 跨品种可比 —— SOXX 的 1 ATR 和 IWM 的 1 ATR 含义相同 (当前波动尺度);
+  2. 跨 regime 自适应 —— 波动率扩张/收缩时阈值自动跟随, 不需要人工调参;
+  3. 统计学含义稳定 —— "距离云带 2 ATR" 大致等价于 "2 个日波动单位",
+     在不同年份读数一致 (本库回测证实: 2023 与 2026 的底部特征读数可直接比较)。
+
+EMA 用 adjust=False 的递推式, 与 TradingView ta.ema 完全一致
+(已用用户的指标导出数据反推验证: 误差 < 0.001)。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def ema(close: pd.Series, span: int) -> pd.Series:
+    """指数均线, alpha = 2/(span+1), 与 TradingView 一致。"""
+    return close.ewm(span=span, adjust=False).mean()
+
+
+def atr(bars: pd.DataFrame, n: int = 14) -> pd.Series:
+    """Wilder 口径的滚动 TR 均值 (简单均值版, 与原型一致)。"""
+    h, lo, c = bars["high"], bars["low"], bars["close"]
+    tr = pd.concat([h - lo, (h - c.shift(1)).abs(), (lo - c.shift(1)).abs()], axis=1).max(axis=1)
+    return tr.rolling(n).mean()
+
+
+def ema_cloud(close: pd.Series, fast: int = 55, slow: int = 89) -> pd.DataFrame:
+    """
+    EMA 云带。55/89 为斐波那契对, 由用户的指标导出数据反推确认
+    (Plot 列与 EMA55 误差 0.0002, Plot.1 与 EMA89 误差 0.002)。
+
+    返回: fast, slow, cloud_lo, cloud_hi, bull (fast>slow)
+    """
+    f, s = ema(close, fast), ema(close, slow)
+    out = pd.DataFrame(
+        {
+            "fast": f,
+            "slow": s,
+            "cloud_lo": pd.concat([f, s], axis=1).min(axis=1),
+            "cloud_hi": pd.concat([f, s], axis=1).max(axis=1),
+        }
+    )
+    out["bull"] = out["fast"] > out["slow"]
+    return out
+
+
+def pivots(series: pd.Series, order: int = 12, kind: str = "high") -> np.ndarray:
+    """
+    摆动高/低点: 左右各 order 根 bar 内的极值点, 返回整数位置数组。
+
+    order 的选择: 12 根 30min bar ≈ 6 个交易小时, 过滤了 bar 级噪声,
+    又保留了日内波段结构 (在 SOXX 数据上与手绘通道的触点吻合)。
+    """
+    v = series.values
+    idx = []
+    for i in range(order, len(v) - order):
+        window = v[i - order : i + order + 1]
+        if (kind == "high" and v[i] == window.max()) or (kind == "low" and v[i] == window.min()):
+            idx.append(i)
+    return np.array(idx, dtype=int)
+
+
+def linreg_channel(close: pd.Series, window: int = 60, k: float = 2.0) -> pd.DataFrame:
+    """
+    滚动回归通道 (稳健版): 中线 = 最小二乘回归, 上下轨 = 中线 ± k×残差σ。
+
+    与 channel.py 的枢轴通道互补: 回归通道每根 bar 都有定义、无拟合失败,
+    适合监控面板批量计算; 枢轴通道更贴近交易者手绘, 适合精细分析。
+    返回: mid, upper, lower, pos (价格在通道中的位置 0~100)
+    """
+    n = len(close)
+    mid = pd.Series(np.nan, index=close.index)
+    sd = pd.Series(np.nan, index=close.index)
+    x = np.arange(window)
+    mx = x.mean()
+    sxx = ((x - mx) ** 2).sum()
+    vals = close.values
+    for i in range(window - 1, n):
+        y = vals[i - window + 1 : i + 1]
+        m = ((x - mx) * (y - y.mean())).sum() / sxx
+        b0 = y.mean() - m * mx
+        resid = y - (m * x + b0)
+        mid.iloc[i] = m * (window - 1) + b0
+        sd.iloc[i] = resid.std()
+    slope = mid.diff()
+    out = pd.DataFrame(
+        {
+            "mid": mid,
+            "upper": mid + k * sd,
+            "lower": mid - k * sd,
+            "slope": slope,
+        }
+    )
+    out["pos"] = ((close - out["lower"]) / (out["upper"] - out["lower"]) * 100).clip(0, 100)
+    return out

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/regime.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/regime.py
@@ -1,0 +1,58 @@
+"""
+regime.py — 趋势状态机 (模块一)
+
+最简形式的双状态机: BULL (EMA55>EMA89) / BEAR (EMA55<EMA89)。
+cross_age 记录距上一次金叉/死叉的 bar 数 —— 新交叉是独立的警报事件,
+老交叉则进入"趋势延续"的监控逻辑。
+
+设计说明: 状态只有两种是刻意的。纠缠区 (两线贴近) 不加第三态,
+因为云带宽度 (cloud width, ATR) 已经作为一个连续变量输出了同样的信息,
+离散状态保持二元可以让下游规则 (压制/底部) 的条件写得干净。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def trend_regime(cloud: pd.DataFrame) -> pd.DataFrame:
+    """输入 ema_cloud 输出, 追加 regime 与 cross_age 两列。"""
+    bull = cloud["bull"]
+    cross = bull.ne(bull.shift(1))
+    out = cloud.copy()
+    out["regime"] = bull.map({True: "BULL", False: "BEAR"})
+    # bars since last cross
+    age = pd.Series(0, index=cloud.index, dtype=int)
+    last_cross = -(10**9)
+    cross_idx = [i for i, c in enumerate(cross.values) if c]
+    ci = 0
+    for i in range(len(age)):
+        if ci < len(cross_idx) and i == cross_idx[ci]:
+            last_cross = i
+            ci += 1
+        age.iloc[i] = i - last_cross if last_cross >= 0 else i + 1
+    out["cross_age"] = age
+    return out
+
+
+def cloud_metrics(bars: pd.DataFrame, cloud: pd.DataFrame, atr_: pd.Series) -> pd.DataFrame:
+    """
+    云带几何量 (全部 ATR 归一化):
+      cloud_dist : 价格到云带的有符号距离 (云内=0, 云上正, 云下负)
+      cloud_width: 云带开口宽度
+      slope_slow : 慢线 26 根斜率 (底部模块的"均线走平度"原料)
+    """
+    px = bars["close"]
+    dist = pd.Series(0.0, index=bars.index)
+    above = px > cloud["cloud_hi"]
+    below = px < cloud["cloud_lo"]
+    dist[above] = (px[above] - cloud["cloud_hi"][above]) / atr_[above]
+    dist[below] = (px[below] - cloud["cloud_lo"][below]) / atr_[below]
+    out = pd.DataFrame(
+        {
+            "cloud_dist": dist,
+            "cloud_width": (cloud["cloud_hi"] - cloud["cloud_lo"]) / atr_,
+            "slope_slow": (cloud["slow"] - cloud["slow"].shift(26)) / atr_,
+        }
+    )
+    return out

--- a/quant/ma-suppression-monitor/ma_suppression_monitor/suppression.py
+++ b/quant/ma-suppression-monitor/ma_suppression_monitor/suppression.py
@@ -1,0 +1,151 @@
+"""
+suppression.py — 均线压制三阶段状态机 (模块三)
+
+核心思想: 把 "一个信号" 拆成 "一台状态机"。
+预判 (ARMED) / 监控 (ENGAGED) / 确认 (CONFIRMED) 各用各的阈值 ——
+信号不稳定的最常见原因, 是进场和出场用了同一个判据,
+价格在边界附近反复穿越时信号疯狂闪烁。
+
+状态转移 (做空向, 多头向完全对称):
+
+    IDLE    --空头排列 且 价格逼近云带(≤arm_dist ATR)--> ARMED
+    ARMED   --探入触发区间 且 深度≥min_depth ATR-------> ENGAGED
+    ARMED   --收盘站上云带上沿+失效缓冲----------------> IDLE   (预判失效)
+    ENGAGED --收盘跌回云带下沿之下---------------------> CONFIRMED (发信号)
+    ENGAGED --收盘站上云带上沿-------------------------> IDLE   (压制失败)
+    CONFIRMED--价格离开云带>cooldown_dist ATR----------> ARMED  (重新武装, 计数+1)
+
+防闪烁三件套:
+  1. 滞后缓冲 (hysteresis): 进入区间 ≠ 退出区间, 缓冲带 0.3 ATR;
+  2. 一次反弹只出一枪: 确认后进入冷却, 重置条件是看价离开云带而非再次触碰;
+  3. 压制计数: 同一趋势段内第 N 次压制单独打标, 供回测分组 (事不过三)。
+
+执行惯例 (与全库一致): 信号在 bar 收盘确认, 成交价为 **下一根 bar 的开盘价**。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pandas as pd
+
+
+@dataclass
+class SuppressionConfig:
+    arm_dist: float = 1.5  # 预判: 距云带下沿 ≤ 1.5 ATR 时武装
+    buffer: float = 0.3  # 滞后缓冲 (ATR)
+    min_depth: float = 0.2  # 有效探入的最小深度 (ATR)
+    cooldown_dist: float = 1.0  # 冷却重置距离 (ATR)
+    channel_pos_min: float = 50  # 预判要求通道位置 ≥ 50% (反弹性质)
+
+
+@dataclass
+class SuppressionEvent:
+    t_armed: pd.Timestamp
+    t_engaged: pd.Timestamp
+    t_confirmed: pd.Timestamp
+    confirm_close: float
+    depth_atr: float  # 探入云带的最深幅度
+    dwell_bars: int  # 在触发区间内停留的 bar 数
+    count: int  # 本趋势段内第几次压制
+
+
+@dataclass
+class SuppressionResult:
+    events: list[SuppressionEvent] = field(default_factory=list)
+    states: pd.Series | None = None  # 每根 bar 的状态, 供可视化
+    failures: int = 0  # 压制失败 (突破云带) 次数
+
+
+def run_suppression_engine(
+    bars: pd.DataFrame,
+    regime: pd.DataFrame,
+    atr_: pd.Series,
+    cfg: SuppressionConfig | None = None,
+    channel_pos: pd.Series | None = None,
+) -> SuppressionResult:
+    """
+    做空向压制状态机。需要 regime (含 bull/cross_age) 与 ATR。
+    channel_pos 可选: 若提供, 预判阶段要求价格在通道上半部。
+    """
+    cfg = cfg or SuppressionConfig()
+    close, high = bars["close"], bars["high"]
+    c_lo, c_hi = regime["cloud_lo"], regime["cloud_hi"]
+    bull = regime["bull"].values
+
+    state = "IDLE"
+    count = 0
+    res = SuppressionResult()
+    states = []
+    t_armed = t_engaged = None
+    max_depth = 0.0
+    dwell = 0
+    prev_regime_bull = bull[0]
+
+    for i in range(len(bars)):
+        a = atr_.iloc[i]
+        if not np_isfinite(a) or a <= 0:
+            states.append(state)
+            continue
+        # 趋势段切换 → 重置计数与状态
+        if bull[i] != prev_regime_bull:
+            count = 0
+            state = "IDLE"
+            prev_regime_bull = bull[i]
+        if bull[i]:  # 做空引擎只在空头排列工作
+            states.append(state)
+            continue
+
+        zone_lo = c_lo.iloc[i] - cfg.buffer * a  # 触发区间下沿 (含滞后缓冲)
+        zone_hi = c_hi.iloc[i]
+        near = close.iloc[i] >= c_lo.iloc[i] - cfg.arm_dist * a
+
+        if state == "IDLE":
+            pos_ok = True if channel_pos is None else channel_pos.iloc[i] >= cfg.channel_pos_min
+            if near and close.iloc[i] < c_lo.iloc[i] and pos_ok:
+                state = "ARMED"
+                t_armed = bars.index[i]
+                max_depth, dwell = 0.0, 0
+        elif state == "ARMED":
+            if close.iloc[i] > zone_hi + cfg.buffer * a:  # 失效: 站上云带
+                state = "IDLE"
+            elif high.iloc[i] >= zone_lo:
+                depth = (min(high.iloc[i], zone_hi) - zone_lo) / a
+                if depth >= cfg.min_depth:
+                    state = "ENGAGED"
+                    t_engaged = bars.index[i]
+                    max_depth, dwell = max(max_depth, depth), 1
+        elif state == "ENGAGED":
+            if high.iloc[i] >= zone_lo:
+                dwell += 1
+                max_depth = max(max_depth, (min(high.iloc[i], zone_hi) - zone_lo) / a)
+            if close.iloc[i] > zone_hi:  # 压制失败
+                res.failures += 1
+                state = "IDLE"
+            elif close.iloc[i] < c_lo.iloc[i]:  # 确认: 跌回云下
+                count += 1
+                res.events.append(
+                    SuppressionEvent(
+                        t_armed=t_armed,
+                        t_engaged=t_engaged,
+                        t_confirmed=bars.index[i],
+                        confirm_close=float(close.iloc[i]),
+                        depth_atr=float(max_depth),
+                        dwell_bars=dwell,
+                        count=count,
+                    )
+                )
+                state = "COOLDOWN"
+        elif state == "COOLDOWN":
+            if abs(close.iloc[i] - c_lo.iloc[i]) > cfg.cooldown_dist * a:
+                state = "ARMED" if close.iloc[i] < c_lo.iloc[i] else "IDLE"
+                t_armed = bars.index[i]
+                max_depth, dwell = 0.0, 0
+        states.append(state)
+
+    res.states = pd.Series(states, index=bars.index, name="suppression_state")
+    return res
+
+
+def np_isfinite(x: float) -> bool:
+    return x == x and abs(x) != float("inf")

--- a/quant/ma-suppression-monitor/macro_channel.py
+++ b/quant/ma-suppression-monitor/macro_channel.py
@@ -1,0 +1,247 @@
+"""
+macro_channel.py — 大尺度通道识别（4h/日线级别）
+
+设计思路：
+  1. 用较大尺度（4小时线）减少噪音
+  2. 找到回撤前的 high（趋势顶点）
+  3. 沿高点画线 → 上轨
+  4. 平行投影到最深低点 → 下轨
+  5. 不依赖 order 参数，直接找"显而易见"的极值点
+
+与 channel.py 的区别：
+  - channel.py: 枚举枢轴对 + 包含性约束，参数敏感，换周期结果变
+  - macro_channel: 先找最大回撤段，再连接段内的高点高点，更接近人眼
+
+不修改原 channel.py，完全独立。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class MacroChannel:
+    slope: float  # $/bar
+    upper_int: float  # 上轨截距
+    lower_int: float  # 下轨截距
+    anchor_idx: int  # 锚点 bar 序号
+    anchor_price: float  # 锚点价格
+    peak_idx: int  # 最高点 bar 序号
+    peak_price: float
+    trough_idx: int  # 最低点 bar 序号
+    trough_price: float
+    upper_touches: list  # 上轨触碰点的 bar 序号列表
+    lower_touches: list  # 下轨触碰点的 bar 序号列表
+    n_bars: int  # 通道覆盖的 bar 数
+    ok: bool
+
+
+def find_drawdown_segment(bars: pd.DataFrame, min_decline_pct: float = 0.08) -> tuple[int, int]:
+    """
+    找最大回撤段：从某个高点到之后的最低点，跌幅 ≥ min_decline_pct。
+    返回 (peak_idx, trough_idx)。
+    """
+    high = bars["high"].values
+    low = bars["low"].values
+    n = len(bars)
+
+    best_peak = 0
+    best_trough = 0
+    best_dd = 0.0
+
+    running_peak = 0
+    for i in range(1, n):
+        if high[i] >= high[running_peak]:
+            running_peak = i
+        else:
+            dd = (low[i] - high[running_peak]) / high[running_peak]
+            if dd < best_dd:
+                best_dd = dd
+                best_peak = running_peak
+                best_trough = i
+
+    if best_peak == best_trough:
+        # fallback: just use global max → global min after it
+        best_peak = int(np.argmax(high))
+        best_trough = best_peak + int(np.argmin(low[best_peak:]))
+
+    return best_peak, best_trough
+
+
+def fit_macro_channel(
+    bars: pd.DataFrame,
+    touch_tol_atr: float = 0.3,
+    touch_tol_pct: float = 0.004,
+) -> MacroChannel:
+    """
+    大尺度通道拟合：
+      1. 找回撤段 [peak → trough]
+      2. 上轨 = 连接 peak 和 trough 之后所有反弹高点中"最好的那条线"
+         "最好" = 包含所有高点（容差 touch_tol_pct）、触点最多
+      3. 下轨 = 平行，过 trough
+      4. 通道延伸到最新 bar
+
+    与 channel.py 的 fit_channel 完全独立。
+    """
+    high = bars["high"].values
+    low = bars["low"].values
+    n = len(bars)
+
+    if n < 10:
+        return MacroChannel(0, 0, 0, 0, 0, 0, 0, 0, 0, [], [], n, False)
+
+    # 1. 找回撤段
+    peak_idx, trough_idx = find_drawdown_segment(bars)
+    peak_price = high[peak_idx]
+    trough_price = low[trough_idx]
+
+    # 2. 找 peak 之后的所有反弹高点（候选用来连上轨）
+    # 一个"反弹高点" = 局部最大值（左右各 2 根 bar 内最高）
+    candidate_highs = []
+    window = 2  # 简单局部极值
+    for i in range(peak_idx + 1, n):
+        left = max(0, i - window)
+        right = min(n, i + window + 1)
+        if high[i] == high[left:right].max() and high[i] < peak_price:
+            candidate_highs.append(i)
+
+    # 候选：peak 本身 + 每个反弹高点 → 枚举所有两点组合
+    all_anchor_points = [(peak_idx, peak_price)] + [(i, high[i]) for i in candidate_highs]
+
+    best = None  # (touches, slope, intercept)
+    for a in range(len(all_anchor_points)):
+        for c in range(a + 1, len(all_anchor_points)):
+            x1, y1 = all_anchor_points[a]
+            x2, y2 = all_anchor_points[c]
+            if x2 == x1:
+                continue
+            m = (y2 - y1) / (x2 - x1)
+            if m >= 0:  # 下降通道要求负斜率
+                continue
+
+            b0 = y1 - m * x1
+            line = m * np.arange(n) + b0
+
+            # 包含性检查：peak 之后所有 high 不能超过 line*(1+tol)
+            violated = False
+            for i in range(peak_idx, n):
+                if high[i] > line[i] * (1 + touch_tol_pct):
+                    violated = True
+                    break
+            if violated:
+                continue
+
+            # 数触点：peak 之后 high 接近 line 的 bar
+            touches = []
+            for i in range(peak_idx, n):
+                if abs(high[i] - line[i]) / max(abs(line[i]), 1e-9) < touch_tol_pct:
+                    touches.append(i)
+
+            if best is None or len(touches) > len(best[0]):
+                best = (touches, m, b0)
+
+    if best is None:
+        # fallback: peak → trough 之后的最高反弹点
+        if candidate_highs:
+            second = candidate_highs[0]
+            m = (high[second] - peak_price) / (second - peak_idx)
+            if m >= 0:
+                m = -0.5  # 强制负斜率
+            b0 = peak_price - m * peak_idx
+            line = m * np.arange(n) + b0
+            touches = [
+                i
+                for i in range(peak_idx, n)
+                if abs(high[i] - line[i]) / max(abs(line[i]), 1e-9) < touch_tol_pct
+            ]
+            best = (touches, m, b0)
+        else:
+            return MacroChannel(
+                0,
+                0,
+                0,
+                peak_idx,
+                peak_price,
+                peak_idx,
+                peak_price,
+                trough_idx,
+                trough_price,
+                [],
+                [],
+                n,
+                False,
+            )
+
+    upper_touches, slope, upper_int = best
+
+    # 3. 下轨 = 平行过 trough
+    lower_int = trough_price - slope * trough_idx
+
+    # 4. 下轨触点
+    lower_line = slope * np.arange(n) + lower_int
+    lower_touches = []
+    for i in range(trough_idx, n):
+        if abs(low[i] - lower_line[i]) / max(abs(lower_line[i]), 1e-9) < touch_tol_pct:
+            lower_touches.append(i)
+
+    return MacroChannel(
+        slope=slope,
+        upper_int=upper_int,
+        lower_int=lower_int,
+        anchor_idx=peak_idx,
+        anchor_price=peak_price,
+        peak_idx=peak_idx,
+        peak_price=peak_price,
+        trough_idx=trough_idx,
+        trough_price=trough_price,
+        upper_touches=upper_touches,
+        lower_touches=lower_touches,
+        n_bars=n,
+        ok=True,
+    )
+
+
+def channel_report(ch: MacroChannel, bars: pd.DataFrame, label: str = "") -> str:
+    """生成通道文字报告"""
+    if not ch.ok:
+        return f"[{label}] NO CHANNEL FITTED"
+
+    n = len(bars)
+    upper_now = ch.slope * (n - 1) + ch.upper_int
+    lower_now = ch.slope * (n - 1) + ch.lower_int
+    last_close = bars["close"].iloc[-1]
+    pos = (last_close - lower_now) / (upper_now - lower_now) * 100
+
+    lines = []
+    lines.append(f"{'=' * 60}")
+    lines.append(f"Macro Channel — {label}")
+    lines.append(f"{'=' * 60}")
+    lines.append(f"Peak:   {bars.index[ch.peak_idx]}  ${ch.peak_price:.1f}")
+    lines.append(f"Trough: {bars.index[ch.trough_idx]}  ${ch.trough_price:.1f}")
+    lines.append(f"Drawdown: {(ch.trough_price / ch.peak_price - 1) * 100:+.1f}%")
+    lines.append(f"Slope: {ch.slope:.5f}/bar")
+    lines.append("")
+    lines.append(f"Upper rail NOW: ${upper_now:.1f}")
+    lines.append(f"Lower rail NOW: ${lower_now:.1f}")
+    lines.append(f"Close:          ${last_close:.1f}")
+    lines.append(f"Position:       {pos:.0f}%")
+    lines.append(
+        f"Dist to upper:  ${upper_now - last_close:.1f} ({(upper_now - last_close) / last_close * 100:+.2f}%)"
+    )
+    lines.append(
+        f"Dist to lower:  ${last_close - lower_now:.1f} ({(lower_now - last_close) / last_close * 100:+.2f}%)"
+    )
+    lines.append("")
+    lines.append(f"Upper touches: {len(ch.upper_touches)} bars")
+    for t in ch.upper_touches:
+        broke = bars["close"].iloc[t] > ch.slope * t + ch.upper_int
+        lines.append(
+            f"  {bars.index[t]}  H=${bars['high'].iloc[t]:.1f}  C=${bars['close'].iloc[t]:.1f}  {'✅' if broke else '—'}"
+        )
+    lines.append(f"Lower touches: {len(ch.lower_touches)} bars")
+
+    return "\n".join(lines)

--- a/quant/ma-suppression-monitor/pyproject.toml
+++ b/quant/ma-suppression-monitor/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ma-suppression-monitor"
+version = "0.1.0"
+description = "均线压制与趋势通道监控系统: EMA云带/枢轴通道/压制状态机/底部评分/双引擎"
+requires-python = ">=3.10"
+dependencies = ["pandas>=2.0", "numpy>=1.24"]
+
+[tool.setuptools.packages.find]
+include = ["ma_suppression_monitor*"]

--- a/quant/ma-suppression-monitor/tests/test_smoke.py
+++ b/quant/ma-suppression-monitor/tests/test_smoke.py
@@ -1,0 +1,168 @@
+"""
+冒烟测试: 用合成 OHLC 数据跑通 ma_suppression_monitor 的全部模块。
+
+不需要真实行情数据, 不访问网络。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ma_suppression_monitor import (
+    DualEngine,
+    atr,
+    baseline,
+    ema_cloud,
+    fit_channel,
+    forward_returns,
+    load_csv,
+    portfolio_sim,
+    resample_bars,
+    score_events,
+    signal_pairs,
+    trend_regime,
+    validate,
+)
+
+
+def make_bars(n: int = 600, seed: int = 7) -> pd.DataFrame:
+    """合成一段 "上涨 → 下跌 → 底部企稳 → 反弹" 的 30min bars。"""
+    rng = np.random.default_rng(seed)
+    t = pd.date_range("2026-01-05 09:30", periods=n, freq="30min", tz="America/New_York")
+    seg = np.concatenate(
+        [
+            np.linspace(0, 30, n // 4),  # 上涨
+            np.linspace(30, -15, n // 2),  # 下跌
+            np.linspace(-15, -12, n // 8),  # 企稳
+            np.linspace(-12, 0, n - n // 4 - n // 2 - n // 8),  # 反弹
+        ]
+    )
+    noise = rng.normal(0, 1.2, n).cumsum() * 0.15 + rng.normal(0, 0.8, n)
+    close = 100 + seg + noise
+    open_ = np.roll(close, 1)
+    open_[0] = close[0]
+    high = np.maximum(open_, close) + rng.uniform(0.1, 0.9, n)
+    low = np.minimum(open_, close) - rng.uniform(0.1, 0.9, n)
+    return pd.DataFrame(
+        {
+            "open": open_,
+            "high": high,
+            "low": low,
+            "close": close,
+            "volume": rng.integers(1e4, 1e6, n).astype(float),
+        },
+        index=t,
+    )
+
+
+@pytest.fixture()
+def bars() -> pd.DataFrame:
+    return validate(make_bars())
+
+
+def test_validate_and_resample(bars):
+    out = resample_bars(bars, "2h")
+    assert 0 < len(out) < len(bars)
+    assert list(out.columns) == ["open", "high", "low", "close", "volume"]
+
+
+def test_load_csv_roundtrip(bars, tmp_path):
+    p = tmp_path / "bars.csv"
+    df = bars.reset_index(names="time")
+    df.to_csv(p, index=False)
+    loaded = load_csv(str(p))
+    assert len(loaded) == len(bars)
+    assert loaded["close"].iloc[-1] == pytest.approx(bars["close"].iloc[-1])
+
+
+def test_dual_engine_frame(bars):
+    eng = DualEngine()
+    frame = eng.run(bars)
+    expected = {
+        "regime",
+        "cross_age",
+        "cloud_dist",
+        "cloud_width",
+        "slope_slow",
+        "chan_pos",
+        "chan_slope",
+        "score",
+        "s_slope",
+        "s_hl",
+        "s_dist",
+        "s_gap",
+        "crash_blocked",
+        "suppression_state",
+        "tests_26",
+        "engine",
+        "alert",
+    }
+    assert expected.issubset(frame.columns)
+    assert len(frame) == len(bars)
+    assert frame["score"].between(0, 100).all()
+    assert frame["regime"].isin(["BULL", "BEAR"]).all()
+    assert (
+        frame["engine"].isin(["SHORT_ACTIVE", "SHORT_REDUCED", "BOTTOM_WATCH", "LONG_SIDE"]).all()
+    )
+
+
+def test_readout(bars):
+    eng = DualEngine()
+    eng.run(bars)
+    out = eng.readout(bars)
+    for key in ["time", "close", "regime", "bottom_score", "engine", "alert"]:
+        assert key in out
+    assert 0 <= out["bottom_score"] <= 100
+
+
+def test_suppression_events_structure(bars):
+    eng = DualEngine()
+    eng.run(bars)
+    for e in eng.suppression_events_:
+        assert e.t_armed <= e.t_engaged <= e.t_confirmed
+        assert e.count >= 1
+        assert e.depth_atr >= 0
+        assert e.dwell_bars >= 1
+
+
+def test_backtest_utils(bars):
+    eng = DualEngine()
+    frame = eng.run(bars)
+    ev_idx = score_events(frame["score"], on=65, off=35)
+    fr = forward_returns(bars, ev_idx, [13, 26])
+    bl = baseline(bars, [13, 26])
+    assert set(bl) == {13, 26}
+    assert {"r13", "r26"}.issubset(fr.columns) or fr.empty
+
+    flags = pd.Series(False, index=bars.index)
+    flags.iloc[::50] = True
+    trades = signal_pairs(bars, flags, flags.shift(25, fill_value=False))
+    assert {"entry_t", "exit_t", "ret", "bars_held"}.issubset(trades.columns) or trades.empty
+
+    pos = pd.Series(0, index=bars.index)
+    pos.iloc[100:400] = 1
+    rets = portfolio_sim(bars, pos)
+    assert len(rets) == len(bars)
+
+
+def test_pivot_channel_and_indicators(bars):
+    ch = fit_channel(bars, direction="down")
+    assert ch.touches >= 0
+    cloud = ema_cloud(bars["close"])
+    regime = trend_regime(cloud)
+    assert (regime["cross_age"] >= 0).all()
+    a = atr(bars)
+    assert a.dropna().gt(0).all()
+
+
+def test_macro_channel(bars):
+    import macro_channel as mc
+
+    down = bars.iloc[len(bars) // 4 : 3 * len(bars) // 4]  # 下跌段
+    ch = mc.fit_macro_channel(down)
+    assert ch.ok
+    assert ch.slope < 0
+    report = mc.channel_report(ch, down, label="test")
+    assert "Macro Channel" in report


### PR DESCRIPTION
## 改动描述

在 `quant/ma-suppression-monitor/` 新增**独立量化工具箱**：均线压制与趋势通道监控系统（EMA 云带 / 枢轴通道 / 压制状态机 / 底部评分 / 双引擎编排）。

- 与 `src/mommy_chaogu` 主程序**完全解耦**：不引用主包代码，主包也不依赖它；自带 `pyproject.toml`（仅依赖 pandas>=2.0、numpy>=1.24），可 `pip install -e .` 单独安装、单独测试。
- 模块构成：
  - `bars.py` 数据加载与规范化（OHLCV 约定，与数据源解耦）
  - `indicators.py` EMA 云带（55/89）/ ATR / 枢轴点 / 回归通道
  - `regime.py` 趋势状态机 BULL/BEAR + 云带几何量（全部 ATR 归一化）
  - `channel.py` 枢轴通道（包含性约束 + 最大触碰拟合，复刻手绘通道）
  - `suppression.py` 压制三阶段状态机（预判 ARMED / 监控 ENGAGED / 确认 CONFIRMED，防闪烁三件套）
  - `bottom.py` 底部形态评分（四特征加权 0~100，含崩盘过滤器封顶 49）
  - `engine.py` 双引擎编排（做空引擎 × 底部评分调制，单一口径警报输出）
  - `backtest.py` 无未来函数回测（信号 t 收盘确认 → t+1 开盘成交）
  - `macro_channel.py`（顶层）大尺度通道（4H/日线），独立于 `channel.py`
- 附带：`README.md`（中文文档）、`examples/run_on_soxx.py`（端到端示例）、`tests/test_smoke.py`（8 个合成数据冒烟测试，不访问网络）。

## 为什么

妈妈炒股目前的监控逻辑散落在主程序里，难以单独验证和复用。这套工具箱把"均线压制 + 趋势通道 + 底部评分"沉淀为独立包：阈值全部 ATR 归一化（跨品种、跨 regime 可比，无需人工调参），状态机化信号（防闪烁），回测执行惯例统一无未来函数，为后续监控面板和告警功能提供可测试的量化底座。

## 怎么验证

- [x] 单元测试已添加（`tests/test_smoke.py`：8 个冒烟测试覆盖全部模块，合成数据，不访问网络）
- [x] 手动测试通过（`examples/run_on_soxx.py` 端到端跑通：双引擎监控帧、当前读数、压制事件、底部评分回测均正常输出）
- [x] 没有破坏现有功能（新增独立目录 `quant/`，不触碰 `src/`、`tests/` 及任何现有文件；仓库 CI 的 pytest testpaths 仅含 `tests/`，coverage 仅统计 `mommy_chaogu`，互不影响）

本地验证记录：

```
ruff format --check .   → 14 files already formatted
ruff check .            → All checks passed!
pytest tests/ -q        → 8 passed in 1.07s
python examples/run_on_soxx.py data_sample.csv
  → bars: 600
  → 当前读数: regime=BULL, bottom_score=99.2, engine=LONG_SIDE, alert=TREND_LONG, 压制事件 4 次
  → 底部评分>65 事件 2 次, r65 均值 +7.01% vs 基准 -3.27%
```

## 质量门

- [x] `ruff format --check .` 通过（按仓库 line-length=100 / py312 配置）
- [x] `ruff check .` 通过（E,F,I,N,W,UP,B,SIM,RUF 全绿）
- [x] `mypy --strict src` 不受影响（本 PR 不改动 `src/`）
- [x] `pytest -m "not network"` 不受影响（工具箱测试在其自带目录内独立运行）

## 检查清单

- [x] 遵循 Conventional Commits（`feat: ...`）
- [x] 代码含中文设计注释（设计动机、参数含义、失败模式教训）
- [x] 无硬编码密钥 / 无网络依赖 / 无新增重型依赖

## 关联 Issue

无

## 截图日志

无（纯后端量化库，示例输出见"怎么验证"）