### PR TITLE
fix(config): harden profile resolution and setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,30 +1,18 @@
-# mommy-chaogu 密钥配置模板
-# 复制为 .env 并填入真实 key：cp .env.example .env
-# .env 已在 .gitignore 中，不会入仓
+# mommy-chaogu 手动配置参考
+#
+# 推荐直接运行 `mommy setup`：向导会验证连接、选择正确的配置作用域，
+# 并以 0600 权限原子写入。只有 CI、容器或无法运行向导时才手动编辑。
 
-# LLM Provider（六选一，与 config.toml 的 agent.provider 对应）
-#DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
-#OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
-#MOONSHOT_API_KEY=sk-xxxxxxxxxxxxxxxxxxxxxxxx
-#ZAI_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxx
-#NOVA_API_KEY=dummy
-#MINIMAX_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxx
+# 选择一个 Provider；AGENT_MODEL 留空时使用该 Provider 的默认模型。
+#AGENT_PROVIDER=zai
+#AGENT_MODEL=glm-4.7
 
-# Agent provider（覆盖 config.toml 的 agent.provider）
-#AGENT_PROVIDER=nova
+# 只填写所选 Provider 对应的一项；不要同时保存不再使用的旧密钥。
+#DEEPSEEK_API_KEY=your-key
+#OPENAI_API_KEY=your-key
+#MOONSHOT_API_KEY=your-key
+#ZAI_API_KEY=your-key
+#MINIMAX_API_KEY=your-key
 
-# Web 安全（使用 --host 0.0.0.0 或公网部署时必填）
-# 可用 `openssl rand -hex 32` 生成
-#MOMMY_API_TOKEN=replace-with-a-long-random-token
-#MOMMY_CORS_ORIGINS=https://stocks.example.com
-
-# Server酱 微信推送
-#SERVER_CHAN_KEY=SCTxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Massive / Polygon 美股行情 API（Base tier 免费，T+1 日线）
-# 文档：https://massive.com/docs/rest/stocks/overview
-#MASSIVE_API_KEY=your_key_here
-#POLYGON_API_KEY=legacy_alias_same_effect
-
-# Web 推送链接前缀
-#WEB_BASE_URL=http://192.168.1.100:8765
+# Web 公网部署、行情源与推送等可选变量见 docs/GETTING-STARTED.md，
+# 不需要为日常本地使用预先配置。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,16 @@ uv run mypy --strict src # type check
 
 推荐运行 `uv run mommy setup`，交互式选择 Provider / 模型、隐藏输入并验证 Key，
 还可继续扫码连接微信。安装用户的配置默认保存到
-`~/.config/mommy-chaogu/.env`（`0600`，不入仓）；若当前 mommy-chaogu 仓库已存在
-项目 `.env`，重新配置时会就地更新它：
+`~/.config/mommy-chaogu/.env`（`0600`，不入仓）；只有当前仓库的项目 `.env` 已包含
+有效 Provider 或 API key 时才会就地更新。可用 `--local` / `--user` 显式选择作用域，
+用 `--check` 脱敏检查生效来源：
 
 ```bash
 cp .env.example .env       # 复制模板
 # 编辑 .env，填入需要的 key
 ```
 
-支持的 key（根据 `config.toml` 里的 `agent.provider` 自动读取对应的）：
+支持的 key（根据生效的 `AGENT_PROVIDER` 自动读取对应的一项）：
 
 | Provider | 环境变量 | 说明 |
 |---|---|---|
@@ -36,7 +37,8 @@ cp .env.example .env       # 复制模板
 | — | `AGENT_PROVIDER` | 覆盖 provider（不重启改 .env） |
 | — | `AGENT_MODEL` | 覆盖聊天模型名 |
 
-优先级：shell 环境变量 > 项目 `.env` > 用户级 `.env` > `config.toml`。provider 配置表
+优先级：shell 环境变量 > 项目 `.env` > 用户级 `.env` > 代码默认值。Provider 与 model
+按来源成组解析，禁止跨层拼接；`config.toml` 仅用于可选高级 Web 参数。provider 配置表
 （base_url / 默认模型 / env key / 温度 / embedding 模型）的单一真相源是
 `src/mommy_chaogu/agent/llm.py`——改 provider 只动它，不要另起表。
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ mommy setup
 
 向导会让你选择 Provider 和模型、隐藏输入并验证 API Key，然后询问是否连接微信。当前支持
 DeepSeek、OpenAI、Kimi、z.ai 和 MiniMax。配置默认以 `0600` 权限保存到
-`~/.config/mommy-chaogu/.env`；如果项目已有 `.env`，则更新项目配置。
+`~/.config/mommy-chaogu/.env`。只有项目 `.env` 已包含有效模型配置时才会继续更新它；
+空白模板不会改变配置作用域。可用 `mommy setup --local` 强制写项目配置，或用
+`mommy setup --user` 强制写用户级配置。
+
+排查配置时运行 `mommy setup --check`。它会显示实际生效的 Provider、模型、密钥变量
+及来源和文件权限，但绝不显示密钥内容。
 
 如果首次配置时跳过了微信，之后可以单独扫码连接：
 

--- a/docs/AGENT-INTERACTION-GUIDE.md
+++ b/docs/AGENT-INTERACTION-GUIDE.md
@@ -326,6 +326,8 @@
 | `OPENAI_API_KEY` | OpenAI LLM | — |
 | `MOONSHOT_API_KEY` | Moonshot / Kimi LLM | — |
 | `AGENT_PROVIDER` | 覆盖 LLM provider | `deepseek` |
+| `AGENT_MODEL` | 覆盖所选 provider 的默认模型 | provider 默认 |
 | `SERVER_CHAN_KEY` | Server酱微信推送 | — |
 
-Provider 配置优先级：shell 环境变量 > `.env` 文件 > `config.toml`。
+配置优先级：shell 环境变量 > 项目 `.env` > 用户级 `.env` > 代码默认值。
+Provider 与 model 在文件层按 profile 成组解析；`config.toml` 不再用于模型配置。

--- a/docs/DETAILED-ARCHITECTURE.md
+++ b/docs/DETAILED-ARCHITECTURE.md
@@ -298,9 +298,11 @@ git clone https://github.com/coffee-man666/mommy-chaogu.git
 cd mommy-chaogu
 uv sync --extra dev
 
-# 配置密钥
-cp .env.example .env
-# 编辑 .env，填入 LLM API key
+# 配置并验证模型（默认写用户级私有配置）
+uv run mommy setup
+
+# 如需项目隔离
+uv run mommy setup --local
 
 # 跑测试确认环境正常
 uv run pytest -m "not network"

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -62,11 +62,13 @@ uv run mommy setup
 4. 以 `0600` 权限保存配置。
 5. 可选显示微信二维码，扫码后启动本地微信网关。
 
-如果当前仓库已有 `.env`，向导会更新它；否则默认写入
-`~/.config/mommy-chaogu/.env`。常用选项：
+默认写入 `~/.config/mommy-chaogu/.env`。如果当前仓库的 `.env` 已包含有效 Provider
+或 API key，向导会继续更新该项目配置；仅复制了空白模板不会改变作用域。常用选项：
 
 ```bash
 uv run mommy setup --local       # 强制写入当前项目 .env
+uv run mommy setup --user        # 强制写入用户级私有配置
+uv run mommy setup --check       # 脱敏检查生效值、来源和文件权限
 uv run mommy setup --no-weixin   # 不询问微信连接
 uv run mommy setup --no-verify   # 暂时无法联网时跳过验证
 ```
@@ -81,7 +83,7 @@ uv run mommy setup --no-verify   # 暂时无法联网时跳过验证
 | z.ai | `ZAI_API_KEY` | `glm-4.7` | GLM Coding API |
 | MiniMax | `MINIMAX_API_KEY` | `MiniMax-M3` | 开放平台按量 API，非 Coding Plan |
 
-也可以复制 `.env.example` 手动配置：
+CI、容器或无法运行向导时，也可以参考 `.env.example` 手动配置：
 
 ```dotenv
 DEEPSEEK_API_KEY=sk-xxxxxxxx
@@ -89,8 +91,11 @@ AGENT_PROVIDER=deepseek
 AGENT_MODEL=deepseek-chat
 ```
 
-配置优先级为：shell 环境变量 → 项目 `.env` → 用户级 `.env` → `config.toml` / 默认值。
-不要提交包含真实密钥的 `.env`。
+配置优先级为：shell 环境变量 → 项目 `.env` → 用户级 `.env` → 代码默认值。
+Provider 和 model 按同一来源成组解析：某层只设置 Provider 时使用该 Provider 的默认
+模型，绝不会拼接下一层的 model。可选 `config.toml` 仅用于高级 Web 参数，不再配置
+Provider、模型或密钥。不要提交包含真实密钥的 `.env`；手动创建后应执行
+`chmod 600 .env`。
 
 ## 4. 不配置 LLM
 
@@ -207,11 +212,12 @@ docker compose up -d
 # 打开 http://127.0.0.1:8000
 ```
 
-没有 Key 时仍可使用数据页面。AI 对话需要项目 `.env`：
+没有 Key 时仍可使用数据页面。AI 对话需要容器读取项目 `.env`：
 
 ```bash
 cp .env.example .env
-# 编辑 .env，填写 Provider Key、AGENT_PROVIDER 和 AGENT_MODEL
+# 编辑 .env，只填写一个 Provider profile 和对应 key
+chmod 600 .env
 docker compose up -d --build
 ```
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -750,12 +750,11 @@ mommy report render             # HTML 报告
 # 临时切换（环境变量）
 AGENT_PROVIDER=zai uv run mommy "今天怎么样"
 
-# 永久切换（.env 文件）
-# 编辑 .env: AGENT_PROVIDER=zai
-# 确保对应的 key 已填入: ZAI_API_KEY=xxx
-
-# 重新运行配置向导
+# 永久切换：重新运行配置向导（同时更新 Provider、model 和对应 key）
 uv run mommy setup
+
+# 排查当前到底读取了哪一层配置（不会显示 key 内容）
+uv run mommy setup --check
 ```
 
 ### 数据库位置

--- a/src/mommy_chaogu/config.py
+++ b/src/mommy_chaogu/config.py
@@ -1,10 +1,11 @@
-"""集中式配置：dataclasses + TOML + .env + 环境变量覆盖。
+"""集中式配置：受管 LLM profile + 可选高级 TOML + 环境变量覆盖。
 
 设计原则：
-- config.toml 提供基础值（可 git 提交不含密钥的版本）
-- ``.env`` 文件持久化密钥（gitignore 排除，不入仓）
+- ``mommy setup`` 原子管理 provider / model / 对应 key
+- 用户级或项目 ``.env`` 持久化私密 profile（gitignore 排除，不入仓）
+- config.toml 仅提供可选、非敏感的高级 Web 参数；旧字段兼容读取
 - 环境变量优先级最高（CI / Docker / cron 场景）
-- load_config(path=None) 读默认路径 config.toml，文件不存在则返回全默认值
+- provider / model 按来源成组解析，禁止跨配置层拼接
 
 支持的 .env / 环境变量：
     DEEPSEEK_API_KEY  → agent.api_key（provider=deepseek 时）
@@ -22,18 +23,22 @@
 from __future__ import annotations
 
 import os
+import threading
 import tomllib
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 
 from mommy_chaogu.agent.llm import SUPPORTED_PROVIDERS as _LLM_PROVIDERS
 from mommy_chaogu.agent.llm import normalize_provider as validate_agent_provider
 from mommy_chaogu.db_paths import MARKET_DB
 
 DEFAULT_CONFIG_PATH = Path("config.toml")
+
+_RUNTIME_ENV_LOCK = threading.RLock()
+_RUNTIME_FILE_VALUES: dict[str, str] = {}
 
 
 def default_user_config_dir() -> Path:
@@ -49,18 +54,173 @@ def default_user_env_path() -> Path:
     return default_user_config_dir() / ".env"
 
 
-def load_runtime_env() -> None:
-    """Load project-local settings first, then user-level fallback settings.
+@dataclass(frozen=True, slots=True)
+class RuntimeEnvStatus:
+    """Safe, redacted description of the effective LLM environment."""
 
-    Existing process environment variables always win. A repository ``.env``
-    can override the user default because it is loaded first without replacing
-    shell values; the user file only fills variables that remain missing.
+    provider: str
+    model: str
+    provider_source: str
+    model_source: str
+    api_key_env: str
+    api_key_source: str
+    configured: bool
+    warnings: tuple[str, ...] = ()
+
+
+def load_runtime_env() -> RuntimeEnvStatus:
+    """Load runtime files with reload-safe, source-aware precedence.
+
+    Precedence is shell > project ``.env`` > user ``.env``. Values previously
+    injected by this function are detached before every load, so editing or
+    deleting a file takes effect in long-running processes instead of becoming
+    permanently stuck in ``os.environ``.
+
+    ``AGENT_PROVIDER`` and ``AGENT_MODEL`` are resolved as one profile. A file
+    that selects a provider but omits its model receives that provider's
+    default; a model from a lower-priority file is never borrowed.
     """
-    local_env = Path(".env")
-    load_dotenv(local_env, override=False)
-    user_env = default_user_env_path()
-    if user_env.absolute() != local_env.absolute():
-        load_dotenv(user_env, override=False)
+    with _RUNTIME_ENV_LOCK:
+        shell_values = dict(os.environ)
+        for key, previous in tuple(_RUNTIME_FILE_VALUES.items()):
+            if os.environ.get(key) == previous:
+                os.environ.pop(key, None)
+                shell_values.pop(key, None)
+        _RUNTIME_FILE_VALUES.clear()
+
+        local_env = Path(".env")
+        local_values = {
+            key: str(value) for key, value in dotenv_values(local_env).items() if value is not None
+        }
+        user_env = default_user_env_path()
+        user_values: dict[str, str] = {}
+        if user_env.absolute() != local_env.absolute():
+            user_values = {
+                key: str(value)
+                for key, value in dotenv_values(user_env).items()
+                if value is not None
+            }
+
+        # General settings merge field-by-field. Provider/model are excluded
+        # and handled atomically below. Only the selected provider key is
+        # injected into the process; other saved credentials remain dormant.
+        merged_file_values = {**user_values, **local_values}
+        provider_env_keys = {str(info["env_key"]) for info in _LLM_PROVIDERS.values()}
+        for key, value in merged_file_values.items():
+            if (
+                key in {"AGENT_PROVIDER", "AGENT_MODEL"}
+                or key in provider_env_keys
+                or key in shell_values
+            ):
+                continue
+            os.environ[key] = value
+            _RUNTIME_FILE_VALUES[key] = value
+
+        shell_provider_present = "AGENT_PROVIDER" in shell_values
+        shell_provider = shell_values.get("AGENT_PROVIDER", "").strip()
+        shell_model = shell_values.get("AGENT_MODEL", "").strip()
+        profile_provider = ""
+        profile_model = ""
+        provider_source = "代码默认"
+        model_source = "Provider 默认"
+        if shell_provider_present:
+            profile_provider = shell_provider
+            profile_model = shell_model
+            provider_source = "Shell 环境变量"
+            model_source = "Shell 环境变量" if shell_model else "Provider 默认"
+        elif str(local_values.get("AGENT_PROVIDER", "")).strip():
+            profile_provider = local_values["AGENT_PROVIDER"].strip()
+            profile_model = shell_model or local_values.get("AGENT_MODEL", "").strip()
+            provider_source = "项目 .env"
+            model_source = (
+                "Shell 环境变量"
+                if shell_model
+                else "项目 .env"
+                if local_values.get("AGENT_MODEL", "").strip()
+                else "Provider 默认"
+            )
+        elif str(user_values.get("AGENT_PROVIDER", "")).strip():
+            profile_provider = user_values["AGENT_PROVIDER"].strip()
+            profile_model = shell_model or user_values.get("AGENT_MODEL", "").strip()
+            provider_source = "用户级配置"
+            model_source = (
+                "Shell 环境变量"
+                if shell_model
+                else "用户级配置"
+                if user_values.get("AGENT_MODEL", "").strip()
+                else "Provider 默认"
+            )
+        elif shell_model:
+            # A model-only shell override intentionally customizes the code
+            # default provider. File-based orphan models remain ignored.
+            profile_model = shell_model
+            model_source = "Shell 环境变量"
+
+        normalized = profile_provider.lower()
+        warnings: list[str] = []
+        if profile_provider:
+            if "AGENT_PROVIDER" not in shell_values:
+                os.environ["AGENT_PROVIDER"] = normalized
+                _RUNTIME_FILE_VALUES["AGENT_PROVIDER"] = normalized
+            if normalized in _LLM_PROVIDERS and "AGENT_MODEL" not in shell_values:
+                resolved_model = profile_model or str(_LLM_PROVIDERS[normalized]["default_model"])
+                os.environ["AGENT_MODEL"] = resolved_model
+                _RUNTIME_FILE_VALUES["AGENT_MODEL"] = resolved_model
+            elif normalized not in _LLM_PROVIDERS:
+                warnings.append(f"不支持的 Provider：{profile_provider}")
+
+        effective_provider = normalized or "deepseek"
+        provider_info = _LLM_PROVIDERS.get(effective_provider)
+        effective_model = profile_model
+        api_key_env = ""
+        if provider_info is not None:
+            effective_model = effective_model or str(provider_info["default_model"])
+            api_key_env = str(provider_info["env_key"])
+
+        api_key_source = "未设置"
+        api_key_present = False
+        if api_key_env:
+            if shell_values.get(api_key_env, ""):
+                api_key_source = "Shell 环境变量"
+                api_key_present = True
+            elif local_values.get(api_key_env, "") and api_key_env not in shell_values:
+                api_key_source = "项目 .env"
+                api_key_present = True
+            elif user_values.get(api_key_env, "") and api_key_env not in shell_values:
+                api_key_source = "用户级配置"
+                api_key_present = True
+            if api_key_present and api_key_env not in shell_values:
+                selected_key = local_values.get(api_key_env) or user_values.get(api_key_env)
+                if selected_key:
+                    os.environ[api_key_env] = selected_key
+                    _RUNTIME_FILE_VALUES[api_key_env] = selected_key
+
+        for path, values, label in (
+            (local_env, local_values, "项目 .env"),
+            (user_env, user_values, "用户级配置"),
+        ):
+            has_secret = any(
+                value and (key.endswith("API_KEY") or key in {"MOMMY_API_TOKEN", "SERVER_CHAN_KEY"})
+                for key, value in values.items()
+            )
+            if has_secret and path.is_file() and path.stat().st_mode & 0o077:
+                warnings.append(f"{label} 权限过宽；请设置为 0600：{path}")
+
+        if local_values.get("AGENT_MODEL") and not local_values.get("AGENT_PROVIDER"):
+            warnings.append("项目 .env 的 AGENT_MODEL 没有同层 Provider，已忽略")
+        if user_values.get("AGENT_MODEL") and not user_values.get("AGENT_PROVIDER"):
+            warnings.append("用户级配置的 AGENT_MODEL 没有同层 Provider，已忽略")
+
+        return RuntimeEnvStatus(
+            provider=effective_provider,
+            model=effective_model,
+            provider_source=provider_source,
+            model_source=model_source,
+            api_key_env=api_key_env,
+            api_key_source=api_key_source,
+            configured=api_key_present,
+            warnings=tuple(warnings),
+        )
 
 
 # provider → 对应的环境变量名（单一真相源在 agent/llm.py，这里派生）
@@ -185,12 +345,14 @@ def _apply_env_overrides(cfg: AppConfig) -> AppConfig:
 
 
 def load_config(path: str | Path | None = None) -> AppConfig:
-    """读取 .env + config.toml 并叠加环境变量覆盖。
+    """读取受管环境 profile + 可选 config.toml。
 
-    加载顺序（后者覆盖前者）：
-    1. ``.env`` 文件（项目根目录，持久化密钥，不入仓）
-    2. ``config.toml``（基础配置）
-    3. 环境变量（CI / Docker / cron 场景，优先级最高）
+    生效优先级：shell > 项目 ``.env`` > 用户级 ``.env`` > 代码默认。
+    Provider 和 model 在每一层作为同一个 profile 解析；高优先级层只
+    指定 Provider 时使用它的默认模型，不继承低优先级层的 model。
+
+    ``config.toml`` 现在只推荐配置高级 Web 参数。为兼容旧安装，仍会
+    读取其中已存在的 legacy 字段，但新模板不再生成 LLM/cache 等配置。
 
     - path 为 None 时使用默认路径 config.toml
     - 文件不存在不报错，返回全默认值 + 环境变量
@@ -217,48 +379,17 @@ def load_config(path: str | Path | None = None) -> AppConfig:
     return _apply_env_overrides(cfg)
 
 
-# TOML 模板（create_default_config 写出）
+# 可选高级 TOML 模板（create_default_config 写出）。
+# LLM profile 和密钥统一由 ``mommy setup`` 管理，不在这里重复配置。
 _CONFIG_TEMPLATE = """\
-# mommy-chaogu 配置文件
-# 密钥配置有两种方式（优先级从高到低）：
-#   1. 环境变量（CI / Docker / cron）
-#   2. .env 文件（项目根目录，持久化，已 gitignore）
-# 根据 provider 自动读取对应的 key：
-#   DEEPSEEK_API_KEY  (provider=deepseek)
-#   OPENAI_API_KEY    (provider=openai)
-#   MOONSHOT_API_KEY  (provider=kimi)
-#   ZAI_API_KEY       (provider=zai)
-#   MINIMAX_API_KEY   (provider=minimax)
-#   SERVER_CHAN_KEY   → push.server_chan_key
-#   AGENT_PROVIDER    → agent.provider
-#   AGENT_MODEL       → agent.model
-#   MOMMY_API_TOKEN   → web.api_token
-#   MOMMY_CORS_ORIGINS → web.cors_origins
-
-db_path = "{market_db}"
-
-[agent]
-provider = "deepseek"          # deepseek / openai / kimi / zai / minimax
-model = "deepseek-chat"        # 留空则用 provider 默认模型
-api_key = ""                   # 建议用 .env 或环境变量
-max_tool_calls = 10
-
-[push]
-server_chan_key = ""           # 建议用 .env 或环境变量
-web_base_url = ""              # 推送消息里 K 线链接的前缀
-
-[cache]
-quote_fetch_interval_seconds = 300        # 报价拉新间隔（5 分钟）
-bar_fetch_interval_seconds = 86400        # K 线拉新间隔（1 天）
-market_snapshot_fetch_interval_seconds = 3600  # 全市场快照（1 小时）
-
-[monitor]
-interval_seconds = 30.0        # 监控轮询间隔
-with_signals = true            # 同时评估告警信号
+# mommy-chaogu 可选高级配置
+# 日常安装与模型配置请运行：mommy setup
+# 本文件不保存 Provider、模型或任何密钥。
 
 [web]
-api_token = ""                         # 远程访问必填；本机默认忽略此值
-cors_origins = []                     # 例如 ["https://stocks.example.com"]
+# 远程认证密钥使用 MOMMY_API_TOKEN 环境变量。
+# cors_origins 也可由 MOMMY_CORS_ORIGINS（逗号分隔）覆盖。
+cors_origins = []
 ws_ticket_ttl_seconds = 60
 agent_max_concurrency = 2
 session_retention_days = 30
@@ -272,5 +403,5 @@ def create_default_config(path: str | Path) -> Path:
     """
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(_CONFIG_TEMPLATE.format(market_db=MARKET_DB), encoding="utf-8")
+    p.write_text(_CONFIG_TEMPLATE, encoding="utf-8")
     return p

--- a/src/mommy_chaogu/setup.py
+++ b/src/mommy_chaogu/setup.py
@@ -20,6 +20,8 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 
+from dotenv import dotenv_values
+
 from mommy_chaogu.agent.llm import SUPPORTED_PROVIDERS
 from mommy_chaogu.config import default_user_env_path, load_runtime_env
 
@@ -31,8 +33,10 @@ WeixinRefresher = Callable[[], bool]
 
 _MANAGED_BEGIN = "# >>> mommy-chaogu managed configuration >>>"
 _MANAGED_END = "# <<< mommy-chaogu managed configuration <<<"
+CONFIG_VERSION_ENV_KEY = "MOMMY_CONFIG_VERSION"
 INTERFACE_ENV_KEY = "MOMMY_INTERFACE"
 VALID_INTERFACES = frozenset({"tui", "web", "cli"})
+_LEGACY_MANAGED_KEYS = frozenset({"NOVA_API_KEY"})
 
 _PROVIDER_DETAILS: dict[str, dict[str, str]] = {
     "deepseek": {
@@ -71,27 +75,31 @@ _PROVIDERS: dict[str, dict[str, str]] = {
 
 
 def preferred_setup_env_path() -> Path:
-    """Update an existing project config; otherwise use the user-level config."""
+    """Update an intentional project profile; otherwise use user config.
+
+    A blank or comments-only ``.env`` copied from the repository template does
+    not opt a checkout into project-scoped credentials.  This keeps source and
+    installed-package onboarding consistent unless the user has actually
+    configured the project (or explicitly passes ``--local``).
+    """
     local_env = Path(".env")
     if local_env.is_file() and Path(".env.example").is_file():
-        return local_env
+        values = dotenv_values(local_env)
+        provider = str(values.get("AGENT_PROVIDER") or "").strip().lower()
+        has_provider_key = any(
+            str(values.get(info["env_key"]) or "").strip() for info in _PROVIDERS.values()
+        )
+        if provider in _PROVIDERS or has_provider_key:
+            return local_env
     return default_user_env_path()
 
 
 def has_env_file(env_path: Path) -> bool:
-    """检查 .env 是否存在且至少含一行非注释的 API key。"""
+    """检查文件是否含当前支持 Provider 的非空 API key。"""
     if not env_path.is_file():
         return False
-    for line in env_path.read_text(encoding="utf-8").splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        if "=" not in stripped:
-            continue
-        key = stripped.split("=", 1)[0].strip()
-        if "API_KEY" in key:
-            return True
-    return False
+    values = dotenv_values(env_path)
+    return any(str(values.get(info["env_key"]) or "").strip() for info in _PROVIDERS.values())
 
 
 def _safe_input(input_func: InputFunc, prompt: str) -> str | None:
@@ -167,6 +175,20 @@ def validate_llm_connection(provider: str, model: str, api_key: str) -> tuple[bo
         if "rate" in message or "429" in message:
             return False, "模型服务限流，请稍后重试"
         return False, f"连接失败（{type(exc).__name__}）"
+
+
+def activate_runtime_llm_profile(provider: str, model: str, api_key: str) -> None:
+    """Hot-activate exactly one provider profile in the current process."""
+    selected_env_key = _PROVIDERS[provider]["env_key"]
+    for info in _PROVIDERS.values():
+        env_key = info["env_key"]
+        if env_key != selected_env_key:
+            os.environ.pop(env_key, None)
+    for legacy_key in _LEGACY_MANAGED_KEYS:
+        os.environ.pop(legacy_key, None)
+    os.environ[selected_env_key] = api_key
+    os.environ["AGENT_PROVIDER"] = provider
+    os.environ["AGENT_MODEL"] = model
 
 
 def connect_weixin() -> bool:
@@ -280,9 +302,7 @@ def run_setup_wizard(
 
     # --- 4. 私密写入配置并让当前进程立即可用 ---
     _write_env_file(env_path, provider, api_key, model=model)
-    os.environ[str(info["env_key"])] = api_key
-    os.environ["AGENT_PROVIDER"] = provider
-    os.environ["AGENT_MODEL"] = model
+    activate_runtime_llm_profile(provider, model, api_key)
     print(f"\n✅ AI 配置已保存：{provider} / {model}")
     print(f"   私有配置文件：{env_path.resolve()}")
 
@@ -339,8 +359,10 @@ def _write_env_file(
 
     managed_keys = {
         *(info["env_key"] for info in _PROVIDERS.values()),
+        *_LEGACY_MANAGED_KEYS,
         "AGENT_PROVIDER",
         "AGENT_MODEL",
+        CONFIG_VERSION_ENV_KEY,
         INTERFACE_ENV_KEY,
         "SERVER_CHAN_KEY",
     }
@@ -358,7 +380,7 @@ def _write_env_file(
         candidate = stripped[1:].strip() if stripped.startswith("#") else stripped
         key = candidate.split("=", 1)[0].strip() if "=" in candidate else ""
         if key in managed_keys:
-            if not stripped.startswith("#") and "=" in stripped:
+            if key not in _LEGACY_MANAGED_KEYS and not stripped.startswith("#") and "=" in stripped:
                 active_values[key] = stripped.split("=", 1)[1]
             continue
         if in_managed_block:
@@ -380,6 +402,7 @@ def _write_env_file(
             _MANAGED_BEGIN,
             "# mommy-chaogu 密钥配置（由首次启动向导生成）",
             f"# 生成时间: {now}",
+            f"{CONFIG_VERSION_ENV_KEY}=2",
             "",
             "# LLM Provider",
         ]
@@ -387,7 +410,8 @@ def _write_env_file(
     for info in _PROVIDERS.values():
         env_key = info["env_key"]
         value = active_values.get(env_key, "")
-        lines.append(f"{env_key}={value}" if value else f"#{env_key}=")
+        if value:
+            lines.append(f"{env_key}={value}")
 
     lines.append("")
     lines.append(f"AGENT_PROVIDER={provider}")
@@ -431,10 +455,6 @@ def check_and_run_setup(*, offer_interface: bool = False) -> bool:
     except ValueError:
         # An invalid provider is recoverable through onboarding.
         pass
-    env_paths = (Path(".env"), default_user_env_path())
-
-    if any(has_env_file(path) for path in env_paths):
-        return True
 
     print("\n⚠️ 未检测到可用的 AI 配置，将启动首次配置向导。")
     print("   稍后也可运行 `mommy setup` 重新配置。\n")
@@ -448,16 +468,44 @@ def check_and_run_setup(*, offer_interface: bool = False) -> bool:
     return False
 
 
+def print_config_status() -> int:
+    """Print a redacted configuration diagnosis suitable for support."""
+    status = load_runtime_env()
+    state = "可用" if status.configured else "未配置"
+    print(f"配置状态：{state}")
+    print(f"Provider：{status.provider}（{status.provider_source}）")
+    print(f"Model：{status.model}（{status.model_source}）")
+    if status.api_key_env:
+        if status.configured:
+            print(f"API key：{status.api_key_env}（{status.api_key_source}，已设置）")
+        else:
+            print(f"API key：{status.api_key_env}（未设置）")
+    for warning in status.warnings:
+        print(f"⚠️ {warning}")
+    return 0 if status.configured and not status.warnings else 1
+
+
 def build_setup_parser() -> argparse.ArgumentParser:
     """Build the standalone onboarding command parser."""
     parser = argparse.ArgumentParser(
         prog="mommy-setup",
         description="配置 AI Provider、模型、API key 和微信连接",
     )
-    parser.add_argument(
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument(
         "--local",
         action="store_true",
         help="写入当前目录 .env，而不是用户级私有配置",
+    )
+    scope.add_argument(
+        "--user",
+        action="store_true",
+        help="强制写入用户级私有配置，即使当前项目已有配置",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="仅检查生效配置、来源和文件权限，不显示密钥",
     )
     parser.add_argument("--no-verify", action="store_true", help="跳过 LLM 连通性验证")
     parser.add_argument("--no-weixin", action="store_true", help="跳过微信扫码步骤")
@@ -467,7 +515,14 @@ def build_setup_parser() -> argparse.ArgumentParser:
 def main_setup() -> None:
     """Standalone ``mommy setup`` / ``mommy-setup`` entry point."""
     args = build_setup_parser().parse_args()
-    env_path = Path(".env") if args.local else preferred_setup_env_path()
+    if args.check:
+        raise SystemExit(print_config_status())
+    if args.local:
+        env_path = Path(".env")
+    elif args.user:
+        env_path = default_user_env_path()
+    else:
+        env_path = preferred_setup_env_path()
     completed = run_setup_wizard(
         env_path,
         verify_llm=not args.no_verify,

--- a/src/mommy_chaogu/web/routes/setup.py
+++ b/src/mommy_chaogu/web/routes/setup.py
@@ -19,8 +19,6 @@
 
 from __future__ import annotations
 
-import os
-
 from fastapi import APIRouter, HTTPException, Request
 
 from mommy_chaogu.agent.llm import SUPPORTED_PROVIDERS
@@ -28,6 +26,7 @@ from mommy_chaogu.config import load_config
 from mommy_chaogu.setup import (
     _PROVIDERS,
     _write_env_file,
+    activate_runtime_llm_profile,
     preferred_setup_env_path,
     validate_llm_connection,
 )
@@ -157,7 +156,7 @@ async def setup_validate(req: SetupValidateIn) -> SetupResultOut:
 async def setup_save(req: SetupSaveIn) -> SetupResultOut:
     """保存 provider/model/key 到私有 .env（0600 原子写）并热更新当前进程。
 
-    复用 setup._write_env_file；随后更新 os.environ 与 AGENT_PROVIDER/AGENT_MODEL，
+    复用 setup._write_env_file；随后热更新当前进程的单一 LLM profile，
     再调用 deps.reload_agent_caches() 让新配置在当前进程内立即生效（无需重启）。
     响应从不回显 key。
     """
@@ -166,7 +165,6 @@ async def setup_save(req: SetupSaveIn) -> SetupResultOut:
     provider = _validate_provider(req.provider)
     model, api_key = _validate_model_key(req.model, req.api_key)
 
-    env_key = str(SUPPORTED_PROVIDERS[provider]["env_key"])
     env_path = preferred_setup_env_path()
 
     # 先在 threadpool 中校验，避免在请求线程里阻塞；校验失败则不写盘。
@@ -177,10 +175,8 @@ async def setup_save(req: SetupSaveIn) -> SetupResultOut:
     # 文件系统写也在 threadpool 中执行，避免阻塞事件循环。
     await asyncio.to_thread(_write_env_file, env_path, provider, api_key, model=model)
 
-    # 让当前进程立即生效（镜像 setup.run_setup_wizard 的 env 设置）。
-    os.environ[env_key] = api_key
-    os.environ["AGENT_PROVIDER"] = provider
-    os.environ["AGENT_MODEL"] = model
+    # 让当前进程立即生效，同时清除其他 provider 的旧密钥。
+    activate_runtime_llm_profile(provider, model, api_key)
 
     # 仅失效 LLM 相关缓存（agent / memory / workflow router），不动共享的
     # market/background/alerter 资源。

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import os
+import re
 from pathlib import Path
 
 import pytest
 
+from mommy_chaogu.agent.llm import SUPPORTED_PROVIDERS
 from mommy_chaogu.config import (
     AppConfig,
     create_default_config,
     load_config,
+    load_runtime_env,
 )
 
 # 所有可能影响测试的 env var
@@ -30,10 +34,9 @@ _ENV_KEYS = (
 
 @pytest.fixture(autouse=True)
 def _isolate_env(monkeypatch: pytest.MonkeyPatch):
-    """每个测试前清除所有相关 env var，mock 掉 load_dotenv 防止 .env 泄漏。"""
+    """每个测试前用空 shell 覆盖隔离本机配置文件。"""
     for key in _ENV_KEYS:
         monkeypatch.setenv(key, "")
-    monkeypatch.setattr("mommy_chaogu.config.load_dotenv", lambda *a, **kw: False)
 
 
 # ---------- 默认值 ----------
@@ -142,10 +145,6 @@ def test_user_env_is_fallback_when_project_env_missing(
     monkeypatch.delenv("AGENT_MODEL")
     monkeypatch.delenv("ZAI_API_KEY")
 
-    # Exercise the real dotenv loader for this integration case.
-    from dotenv import load_dotenv as real_load_dotenv
-
-    monkeypatch.setattr("mommy_chaogu.config.load_dotenv", real_load_dotenv)
     monkeypatch.chdir(tmp_path)
     cfg = load_config(tmp_path / "missing.toml")
 
@@ -169,15 +168,121 @@ def test_project_env_overrides_user_env(monkeypatch: pytest.MonkeyPatch, tmp_pat
     for key in ("AGENT_PROVIDER", "AGENT_MODEL", "ZAI_API_KEY", "OPENAI_API_KEY"):
         monkeypatch.delenv(key)
 
-    from dotenv import load_dotenv as real_load_dotenv
-
-    monkeypatch.setattr("mommy_chaogu.config.load_dotenv", real_load_dotenv)
     monkeypatch.chdir(tmp_path)
     cfg = load_config(tmp_path / "missing.toml")
 
     assert cfg.agent.provider == "openai"
     assert cfg.agent.model == "gpt-5-mini"
     assert cfg.agent.api_key == "project-key"
+
+
+def test_project_provider_without_model_uses_its_default_instead_of_user_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """A project provider selection is an atomic profile boundary.
+
+    A lower-priority user model belongs to the user's provider and must not be
+    combined with the project provider.  Missing project models resolve to the
+    selected provider's default instead.
+    """
+    user_config = tmp_path / "user-config"
+    user_config.mkdir()
+    (user_config / ".env").write_text(
+        "AGENT_PROVIDER=deepseek\nAGENT_MODEL=deepseek-v4-flash\nDEEPSEEK_API_KEY=user-key\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env").write_text(
+        "AGENT_PROVIDER=zai\nZAI_API_KEY=project-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MOMMY_CONFIG_DIR", str(user_config))
+    for key in (
+        "AGENT_PROVIDER",
+        "AGENT_MODEL",
+        "DEEPSEEK_API_KEY",
+        "ZAI_API_KEY",
+    ):
+        monkeypatch.delenv(key)
+
+    monkeypatch.chdir(tmp_path)
+    cfg = load_config(tmp_path / "missing.toml")
+
+    assert cfg.agent.provider == "zai"
+    assert cfg.agent.model == "glm-4.7"
+    assert cfg.agent.api_key == "project-key"
+
+
+def test_runtime_env_reload_replaces_values_injected_by_previous_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Reconfiguration takes effect in a long-running process."""
+    user_config = tmp_path / "user-config"
+    user_config.mkdir()
+    env_file = user_config / ".env"
+    env_file.write_text(
+        "AGENT_PROVIDER=deepseek\nAGENT_MODEL=deepseek-chat\nDEEPSEEK_API_KEY=old-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MOMMY_CONFIG_DIR", str(user_config))
+    for key in (
+        "AGENT_PROVIDER",
+        "AGENT_MODEL",
+        "DEEPSEEK_API_KEY",
+        "ZAI_API_KEY",
+    ):
+        monkeypatch.delenv(key)
+
+    monkeypatch.chdir(tmp_path)
+    load_runtime_env()
+    assert os.environ["AGENT_PROVIDER"] == "deepseek"
+
+    env_file.write_text(
+        "AGENT_PROVIDER=zai\nZAI_API_KEY=new-key\n",
+        encoding="utf-8",
+    )
+    load_runtime_env()
+
+    assert os.environ["AGENT_PROVIDER"] == "zai"
+    assert os.environ["AGENT_MODEL"] == "glm-4.7"
+    assert os.environ["ZAI_API_KEY"] == "new-key"
+
+
+def test_inactive_saved_provider_key_stays_out_of_process_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    (tmp_path / ".env").write_text(
+        "AGENT_PROVIDER=deepseek\nDEEPSEEK_API_KEY=active-key\nOPENAI_API_KEY=dormant-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    for key in (
+        "AGENT_PROVIDER",
+        "AGENT_MODEL",
+        "DEEPSEEK_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key)
+
+    cfg = load_config(tmp_path / "missing.toml")
+
+    assert cfg.agent.api_key == "active-key"
+    assert os.environ["DEEPSEEK_API_KEY"] == "active-key"
+    assert "OPENAI_API_KEY" not in os.environ
+
+
+def test_shell_model_override_is_reported_with_default_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("AGENT_PROVIDER")
+    monkeypatch.setenv("AGENT_MODEL", "deepseek-reasoner")
+
+    status = load_runtime_env()
+
+    assert status.provider == "deepseek"
+    assert status.model == "deepseek-reasoner"
+    assert status.provider_source == "代码默认"
+    assert status.model_source == "Shell 环境变量"
 
 
 def test_minimax_env_override_when_no_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
@@ -212,11 +317,18 @@ def test_create_default_config(tmp_path: Path):
     p = create_default_config(target)
     assert p == target
     assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert "[agent]" not in content
+    assert "[cache]" not in content
+    assert "[monitor]" not in content
+    assert "[push]" not in content
+    assert "db_path" not in content
+    assert "[web]" in content
 
     cfg = load_config(target)
-    # 模板里的值和默认值一致
+    # 高级模板未设置的部分继续使用代码默认值。
     assert cfg.agent.provider == "deepseek"
-    assert cfg.agent.model == "deepseek-chat"
+    assert cfg.agent.model is None
     assert cfg.agent.max_tool_calls == 10
     assert cfg.cache.quote_fetch_interval_seconds == 300
 
@@ -226,3 +338,17 @@ def test_create_default_config_creates_parent_dirs(tmp_path: Path):
     target = tmp_path / "deep" / "nested" / "config.toml"
     create_default_config(target)
     assert target.exists()
+
+
+def test_env_example_matches_supported_llm_profiles():
+    """The manual-install template cannot advertise stale providers."""
+    root = Path(__file__).resolve().parent.parent
+    content = (root / ".env.example").read_text(encoding="utf-8")
+    keys = set(re.findall(r"^#?([A-Z][A-Z0-9_]*API_KEY)=", content, re.MULTILINE))
+    expected = {str(info["env_key"]) for info in SUPPORTED_PROVIDERS.values()}
+
+    assert keys == expected
+    assert "NOVA" not in content
+    assert "AGENT_PROVIDER=" in content
+    assert "AGENT_MODEL=" in content
+    assert "mommy setup" in content

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,7 @@ from mommy_chaogu.setup import (
     choose_interface,
     configured_interface,
     has_env_file,
+    main_setup,
     preferred_setup_env_path,
     run_setup_wizard,
 )
@@ -80,6 +82,12 @@ def test_has_env_file_with_different_provider(tmp_path: Path):
     assert has_env_file(env) is True
 
 
+def test_has_env_file_ignores_deprecated_provider_key(tmp_path: Path):
+    env = tmp_path / ".env"
+    env.write_text("NOVA_API_KEY=legacy-placeholder\n", encoding="utf-8")
+    assert has_env_file(env) is False
+
+
 # ---------- run_setup_wizard ----------
 
 
@@ -99,10 +107,10 @@ def test_wizard_writes_env_deepseek(tmp_path: Path):
     assert "AGENT_PROVIDER=deepseek" in content
     assert "AGENT_MODEL=deepseek-chat" in content
 
-    # 其余 provider 保持注释
-    assert "#OPENAI_API_KEY=" in content
-    assert "#MOONSHOT_API_KEY=" in content
-    assert "#ZAI_API_KEY=" in content
+    # 未配置的 provider 不写空占位，避免看起来像待办项。
+    assert "OPENAI_API_KEY" not in content
+    assert "MOONSHOT_API_KEY" not in content
+    assert "ZAI_API_KEY" not in content
     assert content.count("sk-my-deepseek-key") == 1
 
     assert "SERVER_CHAN_KEY" not in content
@@ -119,7 +127,7 @@ def test_wizard_writes_env_zai(tmp_path: Path):
     assert result is True
     content = env.read_text(encoding="utf-8")
     assert "ZAI_API_KEY=zai-token-xyz" in content
-    assert "#DEEPSEEK_API_KEY=" in content
+    assert "DEEPSEEK_API_KEY" not in content
     assert "AGENT_PROVIDER=zai" in content
     assert "AGENT_MODEL=glm-5" in content
 
@@ -216,20 +224,19 @@ def test_wizard_keyboard_interrupt(tmp_path: Path):
 # ---------- _write_env_file 单独测试 ----------
 
 
-def test_write_env_file_all_providers_present(tmp_path: Path):
+def test_write_env_file_contains_only_configured_provider_keys(tmp_path: Path):
     env = tmp_path / ".env"
     _write_env_file(env, "kimi", "moonshot-key")
     content = env.read_text(encoding="utf-8")
 
-    # 所有 provider 的 env key 都应出现（选中或注释）
-    for info in _PROVIDERS.values():
-        assert info["env_key"] in content
-
-    # 恰好一行无注释（选中的），其余 provider 只保留空占位，不复制 key
+    # 新配置只包含选中的 key，不生成其他 provider 的空占位。
     moonshot_lines = [ln for ln in content.splitlines() if "MOONSHOT_API_KEY" in ln]
     assert len(moonshot_lines) == 1
     assert moonshot_lines[0].startswith("MOONSHOT_API_KEY=")
     assert content.count("moonshot-key") == 1
+    for name, info in _PROVIDERS.items():
+        if name != "kimi":
+            assert info["env_key"] not in content
 
 
 def test_write_env_file_creates_parents(tmp_path: Path):
@@ -239,7 +246,9 @@ def test_write_env_file_creates_parents(tmp_path: Path):
     assert env.stat().st_mode & 0o777 == 0o600
 
 
-def test_write_env_file_preserves_unmanaged_and_existing_provider_keys(tmp_path: Path):
+def test_write_env_file_preserves_unmanaged_and_supported_provider_keys(
+    tmp_path: Path,
+):
     env = tmp_path / ".env"
     env.write_text(
         "CUSTOM_SETTING=keep\nOPENAI_API_KEY=existing-openai\nSERVER_CHAN_KEY=legacy\n",
@@ -253,7 +262,6 @@ def test_write_env_file_preserves_unmanaged_and_existing_provider_keys(tmp_path:
     assert "OPENAI_API_KEY=existing-openai" in content
     assert "ZAI_API_KEY=new-zai" in content
     assert "SERVER_CHAN_KEY=legacy" in content
-    assert content.count("OPENAI_API_KEY=") == 1
 
     _write_env_file(env, "zai", "newer-zai", model="glm-5")
     rewritten = env.read_text(encoding="utf-8")
@@ -263,17 +271,79 @@ def test_write_env_file_preserves_unmanaged_and_existing_provider_keys(tmp_path:
     assert "new-zai" not in rewritten
 
 
+def test_reconfiguration_removes_deprecated_secrets_and_versions_profile(tmp_path: Path):
+    """Migration keeps supported credentials but drops obsolete providers."""
+    env = tmp_path / ".env"
+    env.write_text(
+        "DEEPSEEK_API_KEY=old-deepseek-secret\n"
+        "NOVA_API_KEY=obsolete-secret\n"
+        "AGENT_PROVIDER=deepseek\n"
+        "AGENT_MODEL=deepseek-chat\n",
+        encoding="utf-8",
+    )
+
+    _write_env_file(env, "zai", "new-zai-secret", model="glm-4.7")
+    content = env.read_text(encoding="utf-8")
+
+    assert "ZAI_API_KEY=new-zai-secret" in content
+    assert "DEEPSEEK_API_KEY=old-deepseek-secret" in content
+    assert "obsolete-secret" not in content
+    assert "NOVA_API_KEY" not in content
+    assert "MOMMY_CONFIG_VERSION=2" in content
+    assert "AGENT_PROVIDER=zai" in content
+    assert "AGENT_MODEL=glm-4.7" in content
+
+
 def test_setup_parser_and_preferred_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.chdir(tmp_path)
     args = build_setup_parser().parse_args(["--local", "--no-verify", "--no-weixin"])
     assert args.local is True
     assert args.no_verify is True
     assert args.no_weixin is True
+    user_args = build_setup_parser().parse_args(["--user"])
+    assert user_args.user is True
+    with pytest.raises(SystemExit):
+        build_setup_parser().parse_args(["--local", "--user"])
     assert preferred_setup_env_path() != Path(".env")
 
     Path(".env.example").write_text("", encoding="utf-8")
     Path(".env").write_text("", encoding="utf-8")
+    # A copied/blank template is not an intentional project-scoped profile.
+    assert preferred_setup_env_path() != Path(".env")
+
+    Path(".env").write_text("AGENT_PROVIDER=zai\n", encoding="utf-8")
     assert preferred_setup_env_path() == Path(".env")
+
+
+def test_setup_check_reports_effective_sources_without_exposing_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
+    user_config = tmp_path / "user-config"
+    user_config.mkdir()
+    secret = "never-print-this-secret"
+    (user_config / ".env").write_text(
+        f"AGENT_PROVIDER=zai\nZAI_API_KEY={secret}\n",
+        encoding="utf-8",
+    )
+    (user_config / ".env").chmod(0o600)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("MOMMY_CONFIG_DIR", str(user_config))
+    for key in ("AGENT_PROVIDER", "AGENT_MODEL", "ZAI_API_KEY"):
+        monkeypatch.delenv(key)
+    monkeypatch.setattr(sys, "argv", ["mommy-setup", "--check"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_setup()
+
+    assert exc_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "配置状态：可用" in output
+    assert "Provider：zai（用户级配置）" in output
+    assert "Model：glm-4.7（Provider 默认）" in output
+    assert "API key：ZAI_API_KEY（用户级配置，已设置）" in output
+    assert secret not in output
 
 
 def test_wizard_can_pair_weixin_in_same_flow(tmp_path: Path):
@@ -338,6 +408,8 @@ def test_check_and_run_setup_skips_when_env_exists(tmp_path: Path, monkeypatch: 
     env = tmp_path / ".env"
     env.write_text("DEEPSEEK_API_KEY=sk-present\n", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
+    for key in ("DEEPSEEK_API_KEY", "AGENT_PROVIDER", "AGENT_MODEL"):
+        monkeypatch.delenv(key)
 
     from mommy_chaogu import setup
 
@@ -356,6 +428,28 @@ def test_check_and_run_setup_runs_wizard(tmp_path: Path, monkeypatch: pytest.Mon
 
     monkeypatch.setattr(setup, "run_setup_wizard", lambda *a, **kw: True)
     assert setup.check_and_run_setup() is True
+
+
+def test_check_and_run_setup_repairs_provider_key_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    (tmp_path / ".env").write_text(
+        "AGENT_PROVIDER=zai\nDEEPSEEK_API_KEY=wrong-provider-key\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    from mommy_chaogu import setup
+
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        setup,
+        "run_setup_wizard",
+        lambda *a, **kw: calls.append(True) or True,
+    )
+
+    assert setup.check_and_run_setup() is True
+    assert calls == [True]
 
 
 def test_check_and_run_setup_accepts_shell_configuration(

--- a/tests/test_web/test_baskets.py
+++ b/tests/test_web/test_baskets.py
@@ -19,6 +19,7 @@ from mommy_chaogu.watchlist import WatchlistStore
 def basket_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     from mommy_chaogu.web.app import create_app
     from mommy_chaogu.web.deps import get_adapter, get_watchlist_store
+    from mommy_chaogu.web.routes import baskets as basket_routes
 
     store = WatchlistStore(tmp_path / "portfolio.db")
     group = store.add_group("我的组合", "自定义关注")
@@ -53,6 +54,14 @@ def basket_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient
         )
 
     adapter.get_quotes.side_effect = lambda codes: [item for code in codes if (item := quote(code))]
+
+    def no_background_service() -> object:
+        # Other Web test modules may have started a process-global background
+        # service. This app intentionally exercises the documented no-lifespan
+        # fallback through its injected adapter.
+        raise RuntimeError("background service not started for this app")
+
+    monkeypatch.setattr(basket_routes, "get_service", no_background_service)
     app = create_app()
     app.dependency_overrides[get_watchlist_store] = lambda: store
     app.dependency_overrides[get_adapter] = lambda: adapter

--- a/tests/test_web/test_setup_routes.py
+++ b/tests/test_web/test_setup_routes.py
@@ -336,6 +336,7 @@ class TestSave:
         tmp_path: Path,
     ) -> None:
         client = _make_client(local_setup_enabled=True, loopback=True)
+        monkeypatch.setenv("OPENAI_API_KEY", "stale-openai-key")
 
         written: dict[str, object] = {}
 
@@ -371,6 +372,7 @@ class TestSave:
         assert os.environ.get("DEEPSEEK_API_KEY") == "sk-real"
         assert os.environ.get("AGENT_PROVIDER") == "deepseek"
         assert os.environ.get("AGENT_MODEL") == "deepseek-chat"
+        assert "OPENAI_API_KEY" not in os.environ
 
         # cache invalidation triggered
         assert cleared == ["called"]


### PR DESCRIPTION
## Summary

- resolve `AGENT_PROVIDER` and `AGENT_MODEL` as one source-owned profile across shell, project `.env`, and user `.env`
- make runtime environment reloads replace values previously injected from files instead of keeping stale process state
- add explicit setup scopes (`--local` / `--user`) and a redacted `mommy setup --check` diagnostic
- slim generated `.env` files and `.env.example`, migrate obsolete `NOVA_API_KEY`, and keep inactive supported credentials dormant
- reduce new `config.toml` templates to advanced Web settings while retaining legacy read compatibility
- align CLI and Web reconfiguration, documentation, installation scenarios, and test isolation

## Root cause

The previous loader called `load_dotenv(..., override=False)` for the project file and then the user file. Variables were merged independently, so a project-level `AGENT_PROVIDER=zai` could be combined with a user-level DeepSeek `AGENT_MODEL`. Values loaded into `os.environ` also remained sticky in long-running processes after files changed or were deleted. Setup detection additionally treated any `*API_KEY` entry, including obsolete providers or a key for the wrong active provider, as a usable configuration.

## User impact

Installation and reconfiguration now behave consistently for source checkouts, user-level installs, CLI setup, and Web setup. A provider without an explicit same-layer model uses that provider's default, configuration scope is visible and controllable, stale profiles are diagnosable without exposing secrets, and unsupported or mismatched credentials no longer suppress onboarding.

## Validation

- `.venv/bin/pytest -m "not network"` — **2056 passed, 14 network probes deselected**
- `.venv/bin/mypy --strict src` — **201 source files, no issues**
- Ruff lint and format checks for every changed Python file — passed
- `git diff --check` — passed
- `mommy setup --check` CLI smoke test — passed with redacted output

